### PR TITLE
Remove blueimp-md5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ testem.log
 .node_modules.ember-try/
 bower.json.ember-try
 package.json.ember-try
+jsconfig.json

--- a/addon/components/image.js
+++ b/addon/components/image.js
@@ -1,4 +1,4 @@
 import Component from '@ember/component';
-import Image from 'ember-initials/mixins/image';
+import Image from '@outdoorsyco/ember-initials/mixins/image';
 
 export default Component.extend(Image);

--- a/addon/components/initials.js
+++ b/addon/components/initials.js
@@ -1,4 +1,4 @@
 import Component from '@ember/component';
-import Initials from 'ember-initials/mixins/initials';
+import Initials from '@outdoorsyco/ember-initials/mixins/initials';
 
 export default Component.extend(Initials);

--- a/addon/mixins/image.js
+++ b/addon/mixins/image.js
@@ -1,5 +1,5 @@
 import Mixin from '@ember/object/mixin';
-import Avatar from 'ember-initials/mixins/avatar';
+import Avatar from '@outdoorsyco/ember-initials/mixins/avatar';
 import { reads, or } from '@ember/object/computed';
 
 export default Mixin.create(Avatar, {

--- a/addon/mixins/initials.js
+++ b/addon/mixins/initials.js
@@ -1,10 +1,10 @@
 import Mixin from '@ember/object/mixin';
-import Avatar from 'ember-initials/mixins/avatar';
+import Avatar from '@outdoorsyco/ember-initials/mixins/avatar';
 import { assign } from '@ember/polyfills';
 import { observer, computed } from '@ember/object';
 import { reads } from '@ember/object/computed';
-import ColorIndex from 'ember-initials/utils/color-index';
-import Initials from 'ember-initials/utils/initials';
+import ColorIndex from '@outdoorsyco/ember-initials/utils/color-index';
+import Initials from '@outdoorsyco/ember-initials/utils/initials';
 
 export default Mixin.create(Avatar, {
   image: null,

--- a/app/components/ember-initials/component.js
+++ b/app/components/ember-initials/component.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-initials/components/initials';
+export { default } from '@outdoorsyco/ember-initials/components/initials';

--- a/app/components/ember-initials/image/component.js
+++ b/app/components/ember-initials/image/component.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-initials/components/image';
+export { default } from '@outdoorsyco/ember-initials/components/image';

--- a/app/components/ember-initials/initials/component.js
+++ b/app/components/ember-initials/initials/component.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-initials/components/initials';
+export { default } from '@outdoorsyco/ember-initials/components/initials';

--- a/app/services/ember-initials-store.js
+++ b/app/services/ember-initials-store.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-initials/services/ember-initials-store';
+export { default } from '@outdoorsyco/ember-initials/services/ember-initials-store';

--- a/app/utils/hash.js
+++ b/app/utils/hash.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-initials/utils/hash';
+export { default } from '@outdoorsyco/ember-initials/utils/hash';

--- a/index.js
+++ b/index.js
@@ -2,5 +2,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-initials'
+  name: require('./package').name
 }

--- a/index.js
+++ b/index.js
@@ -2,11 +2,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-initials',
-
-  included: function() {
-    this._super.included.apply(this, arguments);
-    let target = this._findHost();
-    this.import('node_modules/blueimp-md5/js/md5.min.js', { using: [{ transformation: 'amd', as: 'md5' }]});
-  }
+  name: 'ember-initials'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-initials",
-  "version": "3.6.1-beta.1",
+  "version": "3.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-initials",
-  "version": "3.6.0",
+  "version": "3.6.1-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -21,7 +21,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -30,9 +30,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -41,7 +41,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -76,7 +76,7 @@
         "@babel/code-frame": "7.0.0-beta.31",
         "@babel/types": "7.0.0-beta.31",
         "babylon": "7.0.0-beta.31",
-        "lodash": "4.17.4"
+        "lodash": "^4.2.0"
       },
       "dependencies": {
         "babylon": {
@@ -97,10 +97,10 @@
         "@babel/helper-function-name": "7.0.0-beta.31",
         "@babel/types": "7.0.0-beta.31",
         "babylon": "7.0.0-beta.31",
-        "debug": "3.1.0",
-        "globals": "10.4.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "debug": "^3.0.1",
+        "globals": "^10.0.0",
+        "invariant": "^2.2.0",
+        "lodash": "^4.2.0"
       },
       "dependencies": {
         "babylon": {
@@ -132,9 +132,9 @@
       "integrity": "sha512-exAHB+NeFGxkfQ5dSUD03xl3zYGneeSk2Mw2ldTt/nTvYxuDiuSp3DlxgUBgzbdTFG4fbwPk0WtKWOoTXCmNGg==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "2.0.0"
+        "esutils": "^2.0.2",
+        "lodash": "^4.2.0",
+        "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
         "to-fast-properties": {
@@ -151,12 +151,12 @@
       "integrity": "sha512-ph31DfHXRh2CW7zkVvbFG1hRQtcMw4HoQmYwk7VTRQDXFsSi0u+gdksoP1EzDz+D3Sg9oA3BGO6ULPH75rsYvQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-filter-imports": "1.1.1",
-        "broccoli-funnel": "2.0.1",
-        "ember-cli-babel": "6.11.0",
-        "ember-cli-version-checker": "2.1.0",
-        "ember-compatibility-helpers": "0.1.3",
-        "ember-get-config": "0.2.4"
+        "babel-plugin-filter-imports": "^1.1.1",
+        "broccoli-funnel": "^2.0.1",
+        "ember-cli-babel": "^6.3.0",
+        "ember-cli-version-checker": "^2.0.0",
+        "ember-compatibility-helpers": "^0.1.1",
+        "ember-get-config": "^0.2.3"
       }
     },
     "@ember/test-helpers": {
@@ -165,9 +165,9 @@
       "integrity": "sha512-LB1Ybjhl3VjLsL+uZ0uyHyIgMykGQr6J0PAOLr771cSE0nsVJd5ChroBp4OwxbYUNhhkvNY/V4AGtK5gqQf1CQ==",
       "dev": true,
       "requires": {
-        "broccoli-funnel": "2.0.1",
-        "ember-cli-babel": "6.11.0",
-        "ember-cli-htmlbars-inline-precompile": "1.0.2"
+        "broccoli-funnel": "^2.0.1",
+        "ember-cli-babel": "^6.10.0",
+        "ember-cli-htmlbars-inline-precompile": "^1.0.0"
       }
     },
     "@glimmer/di": {
@@ -182,7 +182,7 @@
       "integrity": "sha512-OYOSn2qKPMWRTrInu4W7Ilx2q4+mFfeKS8o8SCWdGN6q/9LnRUvN3vfiAEEfpgoMSvEr8TSGw6/b2WSLWoYAAA==",
       "dev": true,
       "requires": {
-        "@glimmer/di": "0.2.0"
+        "@glimmer/di": "^0.2.0"
       }
     },
     "abbrev": {
@@ -197,7 +197,7 @@
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.17",
+        "mime-types": "~2.1.16",
         "negotiator": "0.6.1"
       }
     },
@@ -213,7 +213,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -236,10 +236,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -254,9 +254,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "alter": {
@@ -265,7 +265,7 @@
       "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
       "dev": true,
       "requires": {
-        "stable": "0.1.6"
+        "stable": "~0.1.3"
       }
     },
     "amd-name-resolver": {
@@ -273,7 +273,7 @@
       "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz",
       "integrity": "sha1-gUMBrf6KLxCfboTV6TUZbvtmlhU=",
       "requires": {
-        "ensure-posix-path": "1.0.2"
+        "ensure-posix-path": "^1.0.1"
       }
     },
     "amdefine": {
@@ -310,8 +310,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "aot-test-generators": {
@@ -320,7 +320,7 @@
       "integrity": "sha1-Q/D2Ffl8spjXkZwbC05rcxCwPNA=",
       "dev": true,
       "requires": {
-        "jsesc": "2.5.1"
+        "jsesc": "^2.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -337,9 +337,9 @@
       "integrity": "sha1-qEaFeegfZzl7tWNMKZU77c0PVsA=",
       "dev": true,
       "requires": {
-        "cson-parser": "1.3.5",
-        "js-yaml": "3.10.0",
-        "lodash": "3.10.1"
+        "cson-parser": "^1.1.0",
+        "js-yaml": "^3.3.0",
+        "lodash": "^3.10.0"
       },
       "dependencies": {
         "lodash": {
@@ -362,8 +362,8 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       },
       "dependencies": {
         "readable-stream": {
@@ -372,13 +372,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -387,7 +387,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -398,7 +398,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       },
       "dependencies": {
         "sprintf-js": {
@@ -415,7 +415,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -447,7 +447,7 @@
       "integrity": "sha1-1ogSkm0UCXogVXmmZ+6vGFakTAc=",
       "dev": true,
       "requires": {
-        "array-to-sentence": "1.1.0"
+        "array-to-sentence": "^1.1.0"
       }
     },
     "array-to-sentence": {
@@ -462,7 +462,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -518,7 +518,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.14.0"
       }
     },
     "async-disk-cache": {
@@ -526,12 +526,12 @@
       "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.3.tgz",
       "integrity": "sha512-GyaWSbDAZCltxSobtj1m1ptXa0+zSdjWs3sM4IqnvhoRwMDHW5786sXQ1RiXbR3ZGuQe6NXMB4N0vUmW163cew==",
       "requires": {
-        "debug": "2.6.9",
-        "heimdalljs": "0.2.5",
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
         "istextorbinary": "2.1.0",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "rsvp": "3.6.2",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.5.3",
+        "rsvp": "^3.0.18",
         "username-sync": "1.0.1"
       }
     },
@@ -552,8 +552,8 @@
       "resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.4.tgz",
       "integrity": "sha512-GQ5X3DT+TefYuFPHdvIPXFTlKnh39U7dwtl+aUBGeKjMea9nBpv3c91DXgeyBQmY07vQ97f3Sr9XHqkamEameQ==",
       "requires": {
-        "async": "2.6.0",
-        "debug": "2.6.9"
+        "async": "^2.4.1",
+        "debug": "^2.6.8"
       }
     },
     "asynckit": {
@@ -579,9 +579,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
@@ -589,25 +589,25 @@
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "debug": "^2.6.8",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.7",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6"
       }
     },
     "babel-eslint": {
@@ -620,8 +620,8 @@
         "@babel/traverse": "7.0.0-beta.31",
         "@babel/types": "7.0.0-beta.31",
         "babylon": "7.0.0-beta.31",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0"
+        "eslint-scope": "~3.7.1",
+        "eslint-visitor-keys": "^1.0.0"
       },
       "dependencies": {
         "babylon": {
@@ -637,14 +637,14 @@
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.6",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -659,9 +659,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -669,10 +669,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -680,10 +680,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -691,9 +691,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -701,11 +701,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -713,8 +713,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -722,8 +722,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -731,8 +731,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -740,9 +740,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -750,11 +750,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -762,12 +762,12 @@
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -775,8 +775,8 @@
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-messages": {
@@ -784,7 +784,7 @@
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -792,7 +792,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-constant-folding": {
@@ -812,7 +812,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz",
       "integrity": "sha512-hZw5qNNGAR02Y+yBUrtsnJHh8OXavkayPRqKGAXnIm4t5rWVpj3ArwsC7TWdpZsBguQvHAeyTxZ7s23yY60HHg==",
       "requires": {
-        "semver": "5.4.1"
+        "semver": "^5.3.0"
       }
     },
     "babel-plugin-ember-legacy-class-constructor": {
@@ -826,7 +826,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz",
       "integrity": "sha512-cv5ZimF5X52uW7Ul83UUxtsFZE6rZYkMv6qWnAeiDLT1/KtpVrTkJpwzDlvJ/FhKJZ43ih4GbFbhuhBKKT7vIw==",
       "requires": {
-        "ember-rfc176-data": "0.3.1"
+        "ember-rfc176-data": "^0.3.0"
       }
     },
     "babel-plugin-eval": {
@@ -847,8 +847,8 @@
       "integrity": "sha1-D0GPtRenxktURhuUeUAIHlGz/Z0=",
       "dev": true,
       "requires": {
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-htmlbars-inline-precompile": {
@@ -887,7 +887,7 @@
       "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
       "dev": true,
       "requires": {
-        "lodash": "3.10.1"
+        "lodash": "^3.9.3"
       },
       "dependencies": {
         "lodash": {
@@ -960,9 +960,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -971,10 +971,10 @@
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-decorators-legacy": {
@@ -983,9 +983,9 @@
       "integrity": "sha1-dBtY9sW86eYCfgiC2cmU8E82aSU=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-decorators": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-syntax-decorators": "^6.1.18",
+        "babel-runtime": "^6.2.0",
+        "babel-template": "^6.3.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -993,7 +993,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1001,7 +1001,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -1009,11 +1009,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1021,15 +1021,15 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -1037,8 +1037,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -1046,7 +1046,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -1054,8 +1054,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -1063,7 +1063,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -1071,9 +1071,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -1081,7 +1081,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -1089,9 +1089,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1099,10 +1099,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1110,9 +1110,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -1120,9 +1120,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1130,8 +1130,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1139,12 +1139,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1152,8 +1152,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1161,7 +1161,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1169,9 +1169,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1179,7 +1179,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1187,7 +1187,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1195,9 +1195,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1205,9 +1205,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1215,7 +1215,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1223,8 +1223,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-undeclared-variables-check": {
@@ -1233,7 +1233,7 @@
       "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
       "dev": true,
       "requires": {
-        "leven": "1.0.2"
+        "leven": "^1.0.2"
       }
     },
     "babel-plugin-undefined-to-void": {
@@ -1247,9 +1247,9 @@
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -1264,36 +1264,36 @@
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.10.0",
-        "invariant": "2.2.2",
-        "semver": "5.4.1"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^2.1.2",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       }
     },
     "babel-register": {
@@ -1301,13 +1301,13 @@
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
@@ -1315,8 +1315,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -1324,11 +1324,11 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -1336,15 +1336,15 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -1352,10 +1352,10 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babel6-plugin-strip-class-callcheck": {
@@ -1381,7 +1381,7 @@
       "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
       "dev": true,
       "requires": {
-        "underscore": "1.8.3"
+        "underscore": ">=1.8.3"
       }
     },
     "backo2": {
@@ -1423,7 +1423,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "better-assert": {
@@ -1469,7 +1469,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "bluebird": {
@@ -1477,11 +1477,6 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
       "dev": true
-    },
-    "blueimp-md5": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.10.0.tgz",
-      "integrity": "sha512-EkNUOi7tpV68TqjpiUz9D9NcT8um2+qtgntmMbi5UKssVX2m/2PLqotcric0RE63pB3HPN/fjf3cKHN2ufGSUQ=="
     },
     "bmp-js": {
       "version": "0.0.3",
@@ -1495,10 +1490,10 @@
       "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
       "dev": true,
       "requires": {
-        "continuable-cache": "0.3.1",
-        "error": "7.0.2",
-        "raw-body": "1.1.7",
-        "safe-json-parse": "1.0.1"
+        "continuable-cache": "^0.3.1",
+        "error": "^7.0.0",
+        "raw-body": "~1.1.0",
+        "safe-json-parse": "~1.0.1"
       },
       "dependencies": {
         "bytes": {
@@ -1513,8 +1508,8 @@
           "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
           "dev": true,
           "requires": {
-            "bytes": "1.0.0",
-            "string_decoder": "0.10.31"
+            "bytes": "1",
+            "string_decoder": "0.10"
           }
         }
       }
@@ -1526,15 +1521,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "http-errors": "1.6.2",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.15"
+        "type-is": "~1.6.15"
       }
     },
     "boolbase": {
@@ -1549,7 +1544,7 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "bootstrap-sass": {
@@ -1564,11 +1559,11 @@
       "integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "mout": "1.1.0",
-        "optimist": "0.6.1",
-        "osenv": "0.1.4",
-        "untildify": "2.1.0"
+        "graceful-fs": "^4.1.3",
+        "mout": "^1.0.0",
+        "optimist": "^0.6.1",
+        "osenv": "^0.1.3",
+        "untildify": "^2.1.0"
       }
     },
     "bower-endpoint-parser": {
@@ -1582,7 +1577,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1592,9 +1587,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "breakable": {
@@ -1609,11 +1604,11 @@
       "integrity": "sha1-BjP8OgsroMLB1W+p/rezMfyDvm0=",
       "dev": true,
       "requires": {
-        "broccoli-asset-rewrite": "1.1.0",
-        "broccoli-filter": "1.2.4",
-        "json-stable-stringify": "1.0.1",
-        "minimatch": "3.0.4",
-        "rsvp": "3.6.2"
+        "broccoli-asset-rewrite": "^1.1.0",
+        "broccoli-filter": "^1.2.2",
+        "json-stable-stringify": "^1.0.0",
+        "minimatch": "^3.0.4",
+        "rsvp": "^3.0.6"
       }
     },
     "broccoli-asset-rewrite": {
@@ -1622,7 +1617,7 @@
       "integrity": "sha1-d6XaVhV6oxjFkRMkXouvtGF/iDA=",
       "dev": true,
       "requires": {
-        "broccoli-filter": "1.2.4"
+        "broccoli-filter": "^1.2.3"
       }
     },
     "broccoli-babel-transpiler": {
@@ -1630,16 +1625,16 @@
       "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
       "integrity": "sha512-o1OUe5RZ5EP5+QICEmRNvWlhMvIciMisVACHu6qUPt6dE0Q0UnI5lUpWTmuXg/X+QuznqD/s1PApIpahv/QMZw==",
       "requires": {
-        "babel-core": "6.26.0",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "broccoli-persistent-filter": "1.4.3",
-        "clone": "2.1.1",
-        "hash-for-dep": "1.2.3",
-        "heimdalljs-logger": "0.1.9",
-        "json-stable-stringify": "1.0.1",
-        "rsvp": "3.6.2",
-        "workerpool": "2.3.0"
+        "babel-core": "^6.14.0",
+        "broccoli-funnel": "^1.0.0",
+        "broccoli-merge-trees": "^1.0.0",
+        "broccoli-persistent-filter": "^1.4.0",
+        "clone": "^2.0.0",
+        "hash-for-dep": "^1.0.2",
+        "heimdalljs-logger": "^0.1.7",
+        "json-stable-stringify": "^1.0.0",
+        "rsvp": "^3.5.0",
+        "workerpool": "^2.2.1"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -1647,20 +1642,20 @@
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           }
         },
         "broccoli-merge-trees": {
@@ -1668,14 +1663,14 @@
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
           "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-plugin": "^1.3.0",
+            "can-symlink": "^1.0.0",
+            "fast-ordered-set": "^1.0.2",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
           }
         }
       }
@@ -1686,7 +1681,7 @@
       "integrity": "sha1-LoYCHIBcNP/I0povtyHPJz6Bnks=",
       "dev": true,
       "requires": {
-        "findup-sync": "0.4.3"
+        "findup-sync": "^0.4.2"
       },
       "dependencies": {
         "findup-sync": {
@@ -1695,10 +1690,10 @@
           "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
           "dev": true,
           "requires": {
-            "detect-file": "0.1.0",
-            "is-glob": "2.0.1",
-            "micromatch": "2.3.11",
-            "resolve-dir": "0.1.1"
+            "detect-file": "^0.1.0",
+            "is-glob": "^2.0.1",
+            "micromatch": "^2.3.7",
+            "resolve-dir": "^0.1.0"
           }
         }
       }
@@ -1709,12 +1704,12 @@
       "integrity": "sha512-4U2jqaR5vxVR0ODxa9bWdrxz69k0WzhWfCGaTSIktJsKIVKmfD5kX1AMOUGBUaIJLJpUOd2t3XPHbXmwjnLCmQ==",
       "dev": true,
       "requires": {
-        "heimdalljs": "0.2.5",
-        "promise-map-series": "0.2.3",
-        "quick-temp": "0.1.8",
-        "rimraf": "2.6.2",
-        "rsvp": "3.6.2",
-        "silent-error": "1.1.0"
+        "heimdalljs": "^0.2.0",
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.2",
+        "rimraf": "^2.2.8",
+        "rsvp": "^3.0.17",
+        "silent-error": "^1.0.1"
       }
     },
     "broccoli-caching-writer": {
@@ -1723,12 +1718,12 @@
       "integrity": "sha1-C9LJapc41qarWQ8HujXFFX19tHY=",
       "dev": true,
       "requires": {
-        "broccoli-kitchen-sink-helpers": "0.3.1",
-        "broccoli-plugin": "1.3.0",
-        "debug": "2.6.9",
-        "rimraf": "2.6.2",
-        "rsvp": "3.6.2",
-        "walk-sync": "0.3.2"
+        "broccoli-kitchen-sink-helpers": "^0.3.1",
+        "broccoli-plugin": "^1.2.1",
+        "debug": "^2.1.1",
+        "rimraf": "^2.2.8",
+        "rsvp": "^3.0.17",
+        "walk-sync": "^0.3.0"
       }
     },
     "broccoli-clean-css": {
@@ -1737,10 +1732,10 @@
       "integrity": "sha1-nbFD2a9+CuecJuOsWpuy1yDqGfo=",
       "dev": true,
       "requires": {
-        "broccoli-persistent-filter": "1.4.3",
-        "clean-css-promise": "0.1.1",
-        "inline-source-map-comment": "1.0.5",
-        "json-stable-stringify": "1.0.1"
+        "broccoli-persistent-filter": "^1.1.6",
+        "clean-css-promise": "^0.1.0",
+        "inline-source-map-comment": "^1.0.5",
+        "json-stable-stringify": "^1.0.0"
       }
     },
     "broccoli-concat": {
@@ -1749,18 +1744,18 @@
       "integrity": "sha1-hv/cUmButZC6n2uJTF7HoBb1t7k=",
       "dev": true,
       "requires": {
-        "broccoli-kitchen-sink-helpers": "0.3.1",
-        "broccoli-plugin": "1.3.0",
-        "broccoli-stew": "1.5.0",
-        "ensure-posix-path": "1.0.2",
-        "fast-sourcemap-concat": "1.2.3",
-        "find-index": "1.1.0",
-        "fs-extra": "1.0.0",
-        "fs-tree-diff": "0.5.7",
-        "lodash.merge": "4.6.0",
-        "lodash.omit": "4.5.0",
-        "lodash.uniq": "4.5.0",
-        "walk-sync": "0.3.2"
+        "broccoli-kitchen-sink-helpers": "^0.3.1",
+        "broccoli-plugin": "^1.3.0",
+        "broccoli-stew": "^1.3.3",
+        "ensure-posix-path": "^1.0.2",
+        "fast-sourcemap-concat": "^1.0.1",
+        "find-index": "^1.1.0",
+        "fs-extra": "^1.0.0",
+        "fs-tree-diff": "^0.5.6",
+        "lodash.merge": "^4.3.0",
+        "lodash.omit": "^4.1.0",
+        "lodash.uniq": "^4.2.0",
+        "walk-sync": "^0.3.1"
       },
       "dependencies": {
         "fs-extra": {
@@ -1769,9 +1764,9 @@
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0"
           }
         }
       }
@@ -1782,7 +1777,7 @@
       "integrity": "sha512-MDKYQ50rxhn+g17DYdfzfEM9DjTuSGu42Db37A8TQHQe8geYEcUZ4SQqZRgzdAI3aRQNlA1yBHJfOeGmOjhLIg==",
       "dev": true,
       "requires": {
-        "broccoli-caching-writer": "3.0.3"
+        "broccoli-caching-writer": "^3.0.3"
       }
     },
     "broccoli-config-replace": {
@@ -1791,10 +1786,10 @@
       "integrity": "sha1-bqh52SpbrWNNETKbUfxfSq/anAA=",
       "dev": true,
       "requires": {
-        "broccoli-kitchen-sink-helpers": "0.3.1",
-        "broccoli-plugin": "1.3.0",
-        "debug": "2.6.9",
-        "fs-extra": "0.24.0"
+        "broccoli-kitchen-sink-helpers": "^0.3.1",
+        "broccoli-plugin": "^1.2.0",
+        "debug": "^2.2.0",
+        "fs-extra": "^0.24.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -1803,10 +1798,10 @@
           "integrity": "sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         }
       }
@@ -1816,12 +1811,12 @@
       "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
       "integrity": "sha512-CixMUndBqTljCc26i6ubhBrGbAWXpWBsGJFce6ZOr76Tul2Ev1xxM0tmf7OjSzdYhkr5BrPd/CNbR9VMPi+NBg==",
       "requires": {
-        "broccoli-plugin": "1.3.0",
-        "fs-tree-diff": "0.5.7",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "symlink-or-copy": "1.1.8",
-        "tree-sync": "1.2.2"
+        "broccoli-plugin": "^1.2.1",
+        "fs-tree-diff": "^0.5.2",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "symlink-or-copy": "^1.1.8",
+        "tree-sync": "^1.2.2"
       }
     },
     "broccoli-favicon": {
@@ -1830,10 +1825,10 @@
       "integrity": "sha1-x3ClqhYDL7rxtcnAM/cbnMWly1E=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
-        "broccoli-caching-writer": "2.3.1",
-        "favicons": "4.8.6",
-        "lodash": "4.17.4"
+        "bluebird": "^3.3.5",
+        "broccoli-caching-writer": "^2.2.1",
+        "favicons": "^4.7.1",
+        "lodash": "^4.10.0"
       },
       "dependencies": {
         "bluebird": {
@@ -1848,12 +1843,12 @@
           "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
           "dev": true,
           "requires": {
-            "broccoli-kitchen-sink-helpers": "0.2.9",
+            "broccoli-kitchen-sink-helpers": "^0.2.5",
             "broccoli-plugin": "1.1.0",
-            "debug": "2.6.9",
-            "rimraf": "2.6.2",
-            "rsvp": "3.6.2",
-            "walk-sync": "0.2.7"
+            "debug": "^2.1.1",
+            "rimraf": "^2.2.8",
+            "rsvp": "^3.0.17",
+            "walk-sync": "^0.2.5"
           }
         },
         "broccoli-kitchen-sink-helpers": {
@@ -1862,8 +1857,8 @@
           "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
           "dev": true,
           "requires": {
-            "glob": "5.0.15",
-            "mkdirp": "0.5.1"
+            "glob": "^5.0.10",
+            "mkdirp": "^0.5.1"
           }
         },
         "broccoli-plugin": {
@@ -1872,10 +1867,10 @@
           "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
           "dev": true,
           "requires": {
-            "promise-map-series": "0.2.3",
-            "quick-temp": "0.1.8",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8"
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^2.3.4",
+            "symlink-or-copy": "^1.0.1"
           }
         },
         "glob": {
@@ -1884,11 +1879,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "walk-sync": {
@@ -1897,8 +1892,8 @@
           "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
           "dev": true,
           "requires": {
-            "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.5"
+            "ensure-posix-path": "^1.0.0",
+            "matcher-collection": "^1.0.0"
           }
         }
       }
@@ -1909,12 +1904,12 @@
       "integrity": "sha1-GzW2fSFavfrdjUnutpSTw55sNFA=",
       "dev": true,
       "requires": {
-        "broccoli-kitchen-sink-helpers": "0.2.9",
-        "broccoli-plugin": "1.3.0",
-        "broccoli-writer": "0.1.1",
-        "mkdirp": "0.5.1",
-        "rsvp": "3.0.21",
-        "symlink-or-copy": "1.1.8"
+        "broccoli-kitchen-sink-helpers": "~0.2.0",
+        "broccoli-plugin": "^1.1.0",
+        "broccoli-writer": "~0.1.1",
+        "mkdirp": "^0.5.1",
+        "rsvp": "~3.0.6",
+        "symlink-or-copy": "^1.0.1"
       },
       "dependencies": {
         "broccoli-kitchen-sink-helpers": {
@@ -1923,8 +1918,8 @@
           "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
           "dev": true,
           "requires": {
-            "glob": "5.0.15",
-            "mkdirp": "0.5.1"
+            "glob": "^5.0.10",
+            "mkdirp": "^0.5.1"
           }
         },
         "glob": {
@@ -1933,11 +1928,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "rsvp": {
@@ -1954,15 +1949,15 @@
       "integrity": "sha1-QJr7lLmjptqfrIE06R4gX0DMczA=",
       "dev": true,
       "requires": {
-        "broccoli-kitchen-sink-helpers": "0.3.1",
-        "broccoli-plugin": "1.3.0",
-        "copy-dereference": "1.0.0",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "promise-map-series": "0.2.3",
-        "rsvp": "3.6.2",
-        "symlink-or-copy": "1.1.8",
-        "walk-sync": "0.3.2"
+        "broccoli-kitchen-sink-helpers": "^0.3.1",
+        "broccoli-plugin": "^1.0.0",
+        "copy-dereference": "^1.0.0",
+        "debug": "^2.2.0",
+        "mkdirp": "^0.5.1",
+        "promise-map-series": "^0.2.1",
+        "rsvp": "^3.0.18",
+        "symlink-or-copy": "^1.0.1",
+        "walk-sync": "^0.3.1"
       }
     },
     "broccoli-funnel": {
@@ -1970,19 +1965,19 @@
       "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
       "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
       "requires": {
-        "array-equal": "1.0.0",
-        "blank-object": "1.0.2",
-        "broccoli-plugin": "1.3.0",
-        "debug": "2.6.9",
-        "fast-ordered-set": "1.0.3",
-        "fs-tree-diff": "0.5.7",
-        "heimdalljs": "0.2.5",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "path-posix": "1.0.0",
-        "rimraf": "2.6.2",
-        "symlink-or-copy": "1.1.8",
-        "walk-sync": "0.3.2"
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^1.3.0",
+        "debug": "^2.2.0",
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^0.5.3",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0",
+        "walk-sync": "^0.3.1"
       }
     },
     "broccoli-funnel-reducer": {
@@ -1996,8 +1991,8 @@
       "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
       "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
       "requires": {
-        "glob": "5.0.15",
-        "mkdirp": "0.5.1"
+        "glob": "^5.0.10",
+        "mkdirp": "^0.5.1"
       },
       "dependencies": {
         "glob": {
@@ -2005,11 +2000,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -2020,13 +2015,13 @@
       "integrity": "sha512-Jvm06UvuMPa5gEH+9/Sb+QpoIodDAYzbyIUEqxniPCdA6JJooa91hQDCTJc32RUV46JNMcLhb3Dl55BdA8v5mw==",
       "dev": true,
       "requires": {
-        "aot-test-generators": "0.1.0",
-        "broccoli-concat": "3.2.2",
-        "broccoli-persistent-filter": "1.4.3",
-        "eslint": "4.14.0",
-        "json-stable-stringify": "1.0.1",
-        "lodash.defaultsdeep": "4.6.0",
-        "md5-hex": "2.0.0"
+        "aot-test-generators": "^0.1.0",
+        "broccoli-concat": "^3.2.2",
+        "broccoli-persistent-filter": "^1.4.3",
+        "eslint": "^4.0.0",
+        "json-stable-stringify": "^1.0.1",
+        "lodash.defaultsdeep": "^4.6.0",
+        "md5-hex": "^2.0.0"
       }
     },
     "broccoli-merge-trees": {
@@ -2034,8 +2029,8 @@
       "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
       "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
       "requires": {
-        "broccoli-plugin": "1.3.0",
-        "merge-trees": "1.0.1"
+        "broccoli-plugin": "^1.3.0",
+        "merge-trees": "^1.0.1"
       }
     },
     "broccoli-middleware": {
@@ -2044,8 +2039,8 @@
       "integrity": "sha1-kvTh+5p5HqmGJFpwd/NcxkjasJc=",
       "dev": true,
       "requires": {
-        "handlebars": "4.0.11",
-        "mime": "1.6.0"
+        "handlebars": "^4.0.4",
+        "mime": "^1.2.11"
       }
     },
     "broccoli-persistent-filter": {
@@ -2053,19 +2048,19 @@
       "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
       "integrity": "sha512-JwNLDvvXJlhUmr+CHcbVhCyp33NbCIAITjQZmJY9e8QzANXh3jpFWlhSFvkWghwKA8rTAKcXkW12agtiZjxr4g==",
       "requires": {
-        "async-disk-cache": "1.3.3",
-        "async-promise-queue": "1.0.4",
-        "broccoli-plugin": "1.3.0",
-        "fs-tree-diff": "0.5.7",
-        "hash-for-dep": "1.2.3",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "mkdirp": "0.5.1",
-        "promise-map-series": "0.2.3",
-        "rimraf": "2.6.2",
-        "rsvp": "3.6.2",
-        "symlink-or-copy": "1.1.8",
-        "walk-sync": "0.3.2"
+        "async-disk-cache": "^1.2.1",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^1.0.0",
+        "fs-tree-diff": "^0.5.2",
+        "hash-for-dep": "^1.0.2",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "mkdirp": "^0.5.1",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^2.6.1",
+        "rsvp": "^3.0.18",
+        "symlink-or-copy": "^1.0.1",
+        "walk-sync": "^0.3.1"
       }
     },
     "broccoli-plugin": {
@@ -2073,10 +2068,10 @@
       "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
       "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
       "requires": {
-        "promise-map-series": "0.2.3",
-        "quick-temp": "0.1.8",
-        "rimraf": "2.6.2",
-        "symlink-or-copy": "1.1.8"
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
       }
     },
     "broccoli-replace": {
@@ -2086,8 +2081,8 @@
       "dev": true,
       "requires": {
         "applause": "1.2.2",
-        "broccoli-persistent-filter": "1.4.3",
-        "minimatch": "3.0.4"
+        "broccoli-persistent-filter": "^1.2.0",
+        "minimatch": "^3.0.0"
       }
     },
     "broccoli-rollup": {
@@ -2096,17 +2091,17 @@
       "integrity": "sha1-Q6CneYVVurVCFwCetHCk/1oFbfA=",
       "dev": true,
       "requires": {
-        "broccoli-plugin": "1.3.0",
-        "es6-map": "0.1.5",
-        "fs-extra": "0.30.0",
-        "fs-tree-diff": "0.5.7",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "md5-hex": "1.3.0",
-        "node-modules-path": "1.0.1",
-        "rollup": "0.41.6",
-        "symlink-or-copy": "1.1.8",
-        "walk-sync": "0.3.2"
+        "broccoli-plugin": "^1.2.1",
+        "es6-map": "^0.1.4",
+        "fs-extra": "^0.30.0",
+        "fs-tree-diff": "^0.5.2",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "md5-hex": "^1.3.0",
+        "node-modules-path": "^1.0.1",
+        "rollup": "^0.41.4",
+        "symlink-or-copy": "^1.1.8",
+        "walk-sync": "^0.3.1"
       },
       "dependencies": {
         "fs-extra": {
@@ -2115,11 +2110,11 @@
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "md5-hex": {
@@ -2128,7 +2123,7 @@
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
-            "md5-o-matic": "0.1.1"
+            "md5-o-matic": "^0.1.1"
           }
         }
       }
@@ -2139,12 +2134,12 @@
       "integrity": "sha512-o2ZUKWiAEvHOM1lNOJ2kcD+ov0ivvTuciCYwIb4+IVEPeGO4vcygqOcEtuviH8mlDn3dB6gGJ/8zTVslU1sI8A==",
       "dev": true,
       "requires": {
-        "broccoli-caching-writer": "3.0.3",
-        "include-path-searcher": "0.1.0",
-        "mkdirp": "0.3.5",
-        "node-sass": "4.7.2",
-        "object-assign": "2.1.1",
-        "rsvp": "3.6.2"
+        "broccoli-caching-writer": "^3.0.3",
+        "include-path-searcher": "^0.1.0",
+        "mkdirp": "^0.3.5",
+        "node-sass": "^4.1.0",
+        "object-assign": "^2.0.0",
+        "rsvp": "^3.0.6"
       },
       "dependencies": {
         "mkdirp": {
@@ -2167,7 +2162,7 @@
       "integrity": "sha1-m/Kp4vjrPtOj8qvd6YjaQ3zNybQ=",
       "dev": true,
       "requires": {
-        "heimdalljs": "0.2.5"
+        "heimdalljs": "^0.2.1"
       }
     },
     "broccoli-source": {
@@ -2181,11 +2176,11 @@
       "integrity": "sha1-vGmQXtejga0yXMDQLe0HEyjr8/M=",
       "dev": true,
       "requires": {
-        "broccoli-caching-writer": "2.3.1",
-        "mkdirp": "0.5.1",
-        "rsvp": "3.6.2",
-        "sri-toolbox": "0.2.0",
-        "symlink-or-copy": "1.1.8"
+        "broccoli-caching-writer": "^2.2.0",
+        "mkdirp": "^0.5.1",
+        "rsvp": "^3.1.0",
+        "sri-toolbox": "^0.2.0",
+        "symlink-or-copy": "^1.0.1"
       },
       "dependencies": {
         "broccoli-caching-writer": {
@@ -2194,12 +2189,12 @@
           "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
           "dev": true,
           "requires": {
-            "broccoli-kitchen-sink-helpers": "0.2.9",
+            "broccoli-kitchen-sink-helpers": "^0.2.5",
             "broccoli-plugin": "1.1.0",
-            "debug": "2.6.9",
-            "rimraf": "2.6.2",
-            "rsvp": "3.6.2",
-            "walk-sync": "0.2.7"
+            "debug": "^2.1.1",
+            "rimraf": "^2.2.8",
+            "rsvp": "^3.0.17",
+            "walk-sync": "^0.2.5"
           }
         },
         "broccoli-kitchen-sink-helpers": {
@@ -2208,8 +2203,8 @@
           "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
           "dev": true,
           "requires": {
-            "glob": "5.0.15",
-            "mkdirp": "0.5.1"
+            "glob": "^5.0.10",
+            "mkdirp": "^0.5.1"
           }
         },
         "broccoli-plugin": {
@@ -2218,10 +2213,10 @@
           "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
           "dev": true,
           "requires": {
-            "promise-map-series": "0.2.3",
-            "quick-temp": "0.1.8",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8"
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^2.3.4",
+            "symlink-or-copy": "^1.0.1"
           }
         },
         "glob": {
@@ -2230,11 +2225,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "walk-sync": {
@@ -2243,8 +2238,8 @@
           "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
           "dev": true,
           "requires": {
-            "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.5"
+            "ensure-posix-path": "^1.0.0",
+            "matcher-collection": "^1.0.0"
           }
         }
       }
@@ -2255,20 +2250,20 @@
       "integrity": "sha1-16+MGFEdzlEOSdMIpi5Zd/RhiDw=",
       "dev": true,
       "requires": {
-        "broccoli-debug": "0.6.4",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "broccoli-persistent-filter": "1.4.3",
-        "broccoli-plugin": "1.3.0",
-        "chalk": "1.1.3",
-        "debug": "2.6.9",
-        "ensure-posix-path": "1.0.2",
-        "fs-extra": "2.1.2",
-        "minimatch": "3.0.4",
-        "resolve": "1.5.0",
-        "rsvp": "3.6.2",
-        "symlink-or-copy": "1.1.8",
-        "walk-sync": "0.3.2"
+        "broccoli-debug": "^0.6.1",
+        "broccoli-funnel": "^1.0.1",
+        "broccoli-merge-trees": "^1.0.0",
+        "broccoli-persistent-filter": "^1.1.6",
+        "broccoli-plugin": "^1.3.0",
+        "chalk": "^1.1.3",
+        "debug": "^2.4.0",
+        "ensure-posix-path": "^1.0.1",
+        "fs-extra": "^2.0.0",
+        "minimatch": "^3.0.2",
+        "resolve": "^1.1.6",
+        "rsvp": "^3.0.16",
+        "symlink-or-copy": "^1.1.8",
+        "walk-sync": "^0.3.0"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -2277,20 +2272,20 @@
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           }
         },
         "broccoli-merge-trees": {
@@ -2299,14 +2294,14 @@
           "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
           "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-plugin": "^1.3.0",
+            "can-symlink": "^1.0.0",
+            "fast-ordered-set": "^1.0.2",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
           }
         },
         "fs-extra": {
@@ -2315,8 +2310,8 @@
           "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0"
           }
         }
       }
@@ -2327,15 +2322,15 @@
       "integrity": "sha1-6PL2xJ4Etukh8ezTDhLwb7deWF8=",
       "dev": true,
       "requires": {
-        "broccoli-plugin": "1.3.0",
-        "debug": "3.1.0",
-        "lodash.defaultsdeep": "4.6.0",
-        "matcher-collection": "1.0.5",
-        "mkdirp": "0.5.1",
-        "source-map-url": "0.4.0",
-        "symlink-or-copy": "1.1.8",
-        "uglify-es": "3.3.3",
-        "walk-sync": "0.3.2"
+        "broccoli-plugin": "^1.2.1",
+        "debug": "^3.1.0",
+        "lodash.defaultsdeep": "^4.6.0",
+        "matcher-collection": "^1.0.5",
+        "mkdirp": "^0.5.0",
+        "source-map-url": "^0.4.0",
+        "symlink-or-copy": "^1.0.1",
+        "uglify-es": "^3.1.3",
+        "walk-sync": "^0.3.2"
       },
       "dependencies": {
         "debug": {
@@ -2365,8 +2360,8 @@
           "integrity": "sha512-W6JcJbOOBoEWvxGt4Y3b/SKMSaS2RsD4Ds7gKpCM/wTiDvxbEKCVqOQWodz5lISFAkkKen6TOKf+ed5GpNouxw==",
           "dev": true,
           "requires": {
-            "commander": "2.12.2",
-            "source-map": "0.6.1"
+            "commander": "~2.12.1",
+            "source-map": "~0.6.1"
           }
         }
       }
@@ -2377,8 +2372,8 @@
       "integrity": "sha1-1NcaqPKvvGejhmuRotp5CEuWqy0=",
       "dev": true,
       "requires": {
-        "quick-temp": "0.1.8",
-        "rsvp": "3.6.2"
+        "quick-temp": "^0.1.0",
+        "rsvp": "^3.0.6"
       }
     },
     "browserslist": {
@@ -2386,8 +2381,8 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.10.0.tgz",
       "integrity": "sha512-WyvzSLsuAVPOjbljXnyeWl14Ae+ukAT8MUuagKVzIDvwBxl4UAwD1xqtyQs2eWYPGUKMeC3Ol62goqYuKqTTcw==",
       "requires": {
-        "caniuse-lite": "1.0.30000784",
-        "electron-to-chromium": "1.3.30"
+        "caniuse-lite": "^1.0.30000780",
+        "electron-to-chromium": "^1.3.28"
       }
     },
     "bser": {
@@ -2396,7 +2391,7 @@
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "dev": true,
       "requires": {
-        "node-int64": "0.4.0"
+        "node-int64": "^0.4.0"
       }
     },
     "buffer-alloc": {
@@ -2405,8 +2400,8 @@
       "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "0.1.1",
-        "buffer-fill": "0.1.0"
+        "buffer-alloc-unsafe": "^0.1.0",
+        "buffer-fill": "^0.1.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -2451,7 +2446,7 @@
       "integrity": "sha1-DD5CycE088neU1jA8WeTYn6pdtY=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "1.0.1"
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "caller-path": {
@@ -2460,7 +2455,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsite": {
@@ -2487,8 +2482,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -2518,7 +2513,7 @@
       "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
       "dev": true,
       "requires": {
-        "rsvp": "3.6.2"
+        "rsvp": "^3.3.3"
       }
     },
     "cardinal": {
@@ -2527,8 +2522,8 @@
       "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
       "dev": true,
       "requires": {
-        "ansicolors": "0.2.1",
-        "redeyed": "1.0.1"
+        "ansicolors": "~0.2.1",
+        "redeyed": "~1.0.0"
       }
     },
     "caseless": {
@@ -2543,8 +2538,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -2552,11 +2547,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "chardet": {
@@ -2571,7 +2566,7 @@
       "integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "cheerio": {
@@ -2580,11 +2575,11 @@
       "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
       "dev": true,
       "requires": {
-        "css-select": "1.0.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.8.3",
-        "lodash": "3.10.1"
+        "css-select": "~1.0.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "~3.8.1",
+        "lodash": "^3.2.0"
       },
       "dependencies": {
         "lodash": {
@@ -2601,15 +2596,15 @@
       "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "circular-json": {
@@ -2630,8 +2625,8 @@
       "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
       "dev": true,
       "requires": {
-        "commander": "2.8.1",
-        "source-map": "0.4.4"
+        "commander": "2.8.x",
+        "source-map": "0.4.x"
       },
       "dependencies": {
         "commander": {
@@ -2640,7 +2635,7 @@
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "source-map": {
@@ -2649,7 +2644,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -2660,9 +2655,9 @@
       "integrity": "sha1-Q/PSyN/LK/BxSBJSzZt2QzwI7ss=",
       "dev": true,
       "requires": {
-        "array-to-error": "1.1.1",
-        "clean-css": "3.4.28",
-        "pinkie-promise": "2.0.1"
+        "array-to-error": "^1.0.0",
+        "clean-css": "^3.4.5",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "cli-cursor": {
@@ -2671,7 +2666,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-spinners": {
@@ -2703,9 +2698,9 @@
       "integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
       "dev": true,
       "requires": {
-        "colors": "1.1.2",
-        "lodash": "3.10.1",
-        "string-width": "1.0.2"
+        "colors": "^1.1.2",
+        "lodash": "^3.10.1",
+        "string-width": "^1.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -2714,7 +2709,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "lodash": {
@@ -2729,9 +2724,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -2748,8 +2743,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       }
     },
@@ -2788,7 +2783,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -2809,7 +2804,7 @@
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -2824,7 +2819,7 @@
       "integrity": "sha512-sgmgEodNLbxnSSoR5a2xH23CoDJ9J5MKsJS/tqplfmJLpikG0oWMpAb+tM8ERQCMpp9I+ERf6SYl158G6GwX0w==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.26.0"
       }
     },
     "commoner": {
@@ -2833,15 +2828,15 @@
       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
       "dev": true,
       "requires": {
-        "commander": "2.12.2",
-        "detective": "4.7.1",
-        "glob": "5.0.15",
-        "graceful-fs": "4.1.11",
-        "iconv-lite": "0.4.19",
-        "mkdirp": "0.5.1",
-        "private": "0.1.8",
-        "q": "1.5.1",
-        "recast": "0.11.23"
+        "commander": "^2.5.0",
+        "detective": "^4.3.1",
+        "glob": "^5.0.15",
+        "graceful-fs": "^4.1.2",
+        "iconv-lite": "^0.4.5",
+        "mkdirp": "^0.5.0",
+        "private": "^0.1.6",
+        "q": "^1.1.2",
+        "recast": "^0.11.17"
       },
       "dependencies": {
         "ast-types": {
@@ -2862,11 +2857,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "recast": {
@@ -2876,9 +2871,9 @@
           "dev": true,
           "requires": {
             "ast-types": "0.9.6",
-            "esprima": "3.1.3",
-            "private": "0.1.8",
-            "source-map": "0.5.7"
+            "esprima": "~3.1.0",
+            "private": "~0.1.5",
+            "source-map": "~0.5.0"
           }
         }
       }
@@ -2907,7 +2902,7 @@
       "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
       "dev": true,
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": ">= 1.30.0 < 2"
       }
     },
     "compression": {
@@ -2916,13 +2911,13 @@
       "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "~1.3.4",
         "bytes": "3.0.0",
-        "compressible": "2.0.12",
+        "compressible": "~2.0.11",
         "debug": "2.6.9",
-        "on-headers": "1.0.1",
+        "on-headers": "~1.0.1",
         "safe-buffer": "5.1.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       }
     },
     "concat-map": {
@@ -2936,9 +2931,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       },
       "dependencies": {
         "readable-stream": {
@@ -2947,13 +2942,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -2962,7 +2957,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -2973,12 +2968,12 @@
       "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
       "dev": true,
       "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "console-control-strings": {
@@ -2993,12 +2988,12 @@
       "integrity": "sha512-/FqFHRwYVjjdeLd/1lhRsyoPCMtDMREJfPU6WCN9LMxPWu3++Cr2wN1uIZfbefVwr59is4UBd6Z2vaJRzTyPWQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "inquirer": "2.0.0",
-        "json-stable-stringify": "1.0.1",
-        "ora": "1.3.0",
-        "through": "2.3.8",
-        "user-info": "1.0.0"
+        "chalk": "^2.1.0",
+        "inquirer": "^2",
+        "json-stable-stringify": "^1.0.1",
+        "ora": "^1.3.0",
+        "through": "^2.3.8",
+        "user-info": "^1.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3007,7 +3002,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3016,9 +3011,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -3027,7 +3022,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3038,7 +3033,7 @@
       "integrity": "sha1-WiUEe8dvcwcmZ8jLUsmJiI9JTGM=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1"
+        "bluebird": "^3.1.1"
       },
       "dependencies": {
         "bluebird": {
@@ -3101,7 +3096,7 @@
       "integrity": "sha512-sA2/4+/PZ/KV6CKgjrVrrUVBKCkdDO02CUlQ0YKTQoYUwPYNOtOAcWlbYhd5v/1JqYaA6oZ4sDlOU4ppVw6Wbg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0"
+        "chalk": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3110,7 +3105,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3119,9 +3114,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -3130,7 +3125,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3147,9 +3142,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -3158,7 +3153,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -3167,7 +3162,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -3184,7 +3179,7 @@
       "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
       "dev": true,
       "requires": {
-        "coffee-script": "1.12.7"
+        "coffee-script": "^1.10.0"
       }
     },
     "css-select": {
@@ -3193,10 +3188,10 @@
       "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "1.0.0",
-        "domutils": "1.4.3",
-        "nth-check": "1.0.1"
+        "boolbase": "~1.0.0",
+        "css-what": "1.0",
+        "domutils": "1.4",
+        "nth-check": "~1.0.0"
       }
     },
     "css-what": {
@@ -3211,7 +3206,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "d": {
@@ -3220,7 +3215,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.37"
+        "es5-ext": "^0.10.9"
       }
     },
     "dag-map": {
@@ -3235,7 +3230,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "debug": {
@@ -3270,16 +3265,16 @@
       "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
       "dev": true,
       "requires": {
-        "alter": "0.2.0",
-        "ast-traverse": "0.1.1",
-        "breakable": "1.0.0",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "simple-fmt": "0.1.0",
-        "simple-is": "0.2.0",
-        "stringmap": "0.2.2",
-        "stringset": "0.2.1",
-        "tryor": "0.1.2",
-        "yargs": "3.27.0"
+        "alter": "~0.2.0",
+        "ast-traverse": "~0.1.1",
+        "breakable": "~1.0.0",
+        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+        "simple-fmt": "~0.1.0",
+        "simple-is": "~0.2.0",
+        "stringmap": "~0.2.2",
+        "stringset": "~0.2.1",
+        "tryor": "~0.1.2",
+        "yargs": "~3.27.0"
       },
       "dependencies": {
         "esprima-fb": {
@@ -3296,13 +3291,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "pify": {
@@ -3343,7 +3338,7 @@
       "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
       "dev": true,
       "requires": {
-        "fs-exists-sync": "0.1.0"
+        "fs-exists-sync": "^0.1.0"
       }
     },
     "detect-indent": {
@@ -3351,7 +3346,7 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "detective": {
@@ -3360,8 +3355,8 @@
       "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "5.3.0",
-        "defined": "1.0.0"
+        "acorn": "^5.2.1",
+        "defined": "^1.0.0"
       }
     },
     "diff": {
@@ -3376,7 +3371,7 @@
       "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "dom-serializer": {
@@ -3385,8 +3380,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -3415,7 +3410,7 @@
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -3424,7 +3419,7 @@
       "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "dot-prop": {
@@ -3433,7 +3428,7 @@
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -3443,7 +3438,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "editions": {
@@ -3467,7 +3462,7 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz",
       "integrity": "sha512-zx1Prv7kYLfc4OA60FhxGbSo4qrEjgSzpo1/37i7l9ltXPYOoQBtjQxY9KmsgfHnBxHlBGXwLlsbt/gub1w5lw==",
       "requires": {
-        "electron-releases": "2.1.0"
+        "electron-releases": "^2.1.0"
       }
     },
     "ember-ajax": {
@@ -3476,7 +3471,7 @@
       "integrity": "sha1-jyHp2gwdQzz4eaqFX85GTVF+mrU=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.11.0"
+        "ember-cli-babel": "^6.0.0"
       }
     },
     "ember-assign-polyfill": {
@@ -3485,8 +3480,8 @@
       "integrity": "sha512-XKKejlKGF3UgZOAr3VksOrgCKroZscgA91rR5gRZk0wVOsiay3aFdkM5jeOFjfi1xmBP9wrn1i32P945Q6J4sw==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.11.0",
-        "ember-cli-version-checker": "2.1.0"
+        "ember-cli-babel": "^6.8.2",
+        "ember-cli-version-checker": "^2.0.0"
       }
     },
     "ember-bootstrap": {
@@ -3495,24 +3490,24 @@
       "integrity": "sha512-hUfUf7ZTulOeurF/9Ld2kszM8e9yzxhxyNpHdhfGvFZ3sK1b7s7i4sXlE5qtL8cxJcW1f9uullV54/VamCn+Yg==",
       "dev": true,
       "requires": {
-        "broccoli-debug": "0.6.4",
-        "broccoli-funnel": "2.0.1",
-        "broccoli-merge-trees": "2.0.0",
-        "broccoli-stew": "1.5.0",
-        "chalk": "2.3.0",
-        "ember-assign-polyfill": "2.1.0",
-        "ember-cli-babel": "6.11.0",
+        "broccoli-debug": "^0.6.3",
+        "broccoli-funnel": "^2.0.0",
+        "broccoli-merge-trees": "^2.0.0",
+        "broccoli-stew": "^1.4.0",
+        "chalk": "^2.1.0",
+        "ember-assign-polyfill": "^2.0.1",
+        "ember-cli-babel": "^6.8.2",
         "ember-cli-build-config-editor": "0.5.0",
-        "ember-cli-htmlbars": "2.0.3",
-        "ember-cli-version-checker": "2.1.0",
-        "ember-popper": "0.8.2",
-        "ember-runtime-enumerable-includes-polyfill": "2.1.0",
-        "ember-wormhole": "0.5.4",
-        "findup-sync": "1.0.0",
-        "fs-extra": "4.0.3",
-        "resolve": "1.5.0",
-        "rsvp": "4.7.0",
-        "silent-error": "1.1.0"
+        "ember-cli-htmlbars": "^2.0.2",
+        "ember-cli-version-checker": "^2.1.0",
+        "ember-popper": "^0.8.2",
+        "ember-runtime-enumerable-includes-polyfill": "^2.0.0",
+        "ember-wormhole": "^0.5.2",
+        "findup-sync": "^1.0.0",
+        "fs-extra": "^4.0.1",
+        "resolve": "^1.5.0",
+        "rsvp": "^4.0.1",
+        "silent-error": "^1.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3521,7 +3516,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3530,9 +3525,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "rsvp": {
@@ -3547,7 +3542,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3559,88 +3554,88 @@
       "dev": true,
       "requires": {
         "amd-name-resolver": "1.0.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "bower-config": "1.4.1",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+        "bower-config": "^1.3.0",
         "bower-endpoint-parser": "0.2.2",
-        "broccoli-babel-transpiler": "6.1.2",
-        "broccoli-brocfile-loader": "0.18.0",
-        "broccoli-builder": "0.18.10",
-        "broccoli-concat": "3.2.2",
-        "broccoli-config-loader": "1.0.1",
-        "broccoli-config-replace": "1.1.2",
-        "broccoli-debug": "0.6.4",
-        "broccoli-funnel": "2.0.1",
-        "broccoli-funnel-reducer": "1.0.0",
-        "broccoli-merge-trees": "2.0.0",
-        "broccoli-middleware": "1.0.0",
-        "broccoli-source": "1.1.0",
-        "broccoli-stew": "1.5.0",
-        "calculate-cache-key-for-tree": "1.1.0",
-        "capture-exit": "1.2.0",
-        "chalk": "2.3.0",
-        "clean-base-url": "1.0.0",
-        "compression": "1.7.1",
-        "configstore": "3.1.1",
-        "console-ui": "2.1.0",
-        "core-object": "3.1.5",
-        "dag-map": "2.0.2",
-        "diff": "3.4.0",
-        "ember-cli-broccoli-sane-watcher": "2.0.4",
-        "ember-cli-is-package-missing": "1.0.0",
-        "ember-cli-legacy-blueprints": "0.1.5",
-        "ember-cli-lodash-subset": "2.0.1",
-        "ember-cli-normalize-entity-name": "1.0.0",
-        "ember-cli-preprocess-registry": "3.1.1",
-        "ember-cli-string-utils": "1.1.0",
-        "ember-try": "0.2.22",
-        "ensure-posix-path": "1.0.2",
-        "execa": "0.8.0",
+        "broccoli-babel-transpiler": "^6.0.0",
+        "broccoli-brocfile-loader": "^0.18.0",
+        "broccoli-builder": "^0.18.8",
+        "broccoli-concat": "^3.2.2",
+        "broccoli-config-loader": "^1.0.0",
+        "broccoli-config-replace": "^1.1.2",
+        "broccoli-debug": "^0.6.3",
+        "broccoli-funnel": "^2.0.0",
+        "broccoli-funnel-reducer": "^1.0.0",
+        "broccoli-merge-trees": "^2.0.0",
+        "broccoli-middleware": "^1.0.0",
+        "broccoli-source": "^1.1.0",
+        "broccoli-stew": "^1.2.0",
+        "calculate-cache-key-for-tree": "^1.0.0",
+        "capture-exit": "^1.1.0",
+        "chalk": "^2.0.1",
+        "clean-base-url": "^1.0.0",
+        "compression": "^1.4.4",
+        "configstore": "^3.0.0",
+        "console-ui": "^2.0.0",
+        "core-object": "^3.1.3",
+        "dag-map": "^2.0.2",
+        "diff": "^3.2.0",
+        "ember-cli-broccoli-sane-watcher": "^2.0.4",
+        "ember-cli-is-package-missing": "^1.0.0",
+        "ember-cli-legacy-blueprints": "^0.1.2",
+        "ember-cli-lodash-subset": "^2.0.1",
+        "ember-cli-normalize-entity-name": "^1.0.0",
+        "ember-cli-preprocess-registry": "^3.1.0",
+        "ember-cli-string-utils": "^1.0.0",
+        "ember-try": "^0.2.15",
+        "ensure-posix-path": "^1.0.2",
+        "execa": "^0.8.0",
         "exists-sync": "0.0.4",
-        "exit": "0.1.2",
-        "express": "4.16.2",
-        "filesize": "3.5.11",
-        "find-up": "2.1.0",
-        "fs-extra": "4.0.3",
-        "fs-tree-diff": "0.5.7",
-        "get-caller-file": "1.0.2",
-        "git-repo-info": "1.4.1",
+        "exit": "^0.1.2",
+        "express": "^4.12.3",
+        "filesize": "^3.1.3",
+        "find-up": "^2.1.0",
+        "fs-extra": "^4.0.0",
+        "fs-tree-diff": "^0.5.2",
+        "get-caller-file": "^1.0.0",
+        "git-repo-info": "^1.4.1",
         "glob": "7.1.1",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-fs-monitor": "0.1.0",
-        "heimdalljs-graph": "0.3.4",
-        "heimdalljs-logger": "0.1.9",
-        "http-proxy": "1.16.2",
-        "inflection": "1.12.0",
-        "is-git-url": "1.0.0",
-        "isbinaryfile": "3.0.2",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
+        "heimdalljs": "^0.2.3",
+        "heimdalljs-fs-monitor": "^0.1.0",
+        "heimdalljs-graph": "^0.3.1",
+        "heimdalljs-logger": "^0.1.7",
+        "http-proxy": "^1.9.0",
+        "inflection": "^1.7.0",
+        "is-git-url": "^1.0.0",
+        "isbinaryfile": "^3.0.0",
+        "js-yaml": "^3.6.1",
+        "json-stable-stringify": "^1.0.1",
         "leek": "0.0.24",
-        "lodash.template": "4.4.0",
-        "markdown-it": "8.4.0",
+        "lodash.template": "^4.2.5",
+        "markdown-it": "^8.3.0",
         "markdown-it-terminal": "0.1.0",
-        "minimatch": "3.0.4",
-        "morgan": "1.9.0",
-        "node-modules-path": "1.0.1",
-        "nopt": "3.0.6",
-        "npm-package-arg": "4.2.1",
-        "portfinder": "1.0.13",
-        "promise-map-series": "0.2.3",
-        "quick-temp": "0.1.8",
-        "resolve": "1.5.0",
-        "rsvp": "4.7.0",
-        "sane": "1.7.0",
-        "semver": "5.4.1",
-        "silent-error": "1.1.0",
-        "sort-package-json": "1.7.1",
-        "symlink-or-copy": "1.1.8",
+        "minimatch": "^3.0.0",
+        "morgan": "^1.8.1",
+        "node-modules-path": "^1.0.0",
+        "nopt": "^3.0.6",
+        "npm-package-arg": "^4.1.1",
+        "portfinder": "^1.0.7",
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.8",
+        "resolve": "^1.3.0",
+        "rsvp": "^4.7.0",
+        "sane": "^1.6.0",
+        "semver": "^5.1.1",
+        "silent-error": "^1.0.0",
+        "sort-package-json": "^1.4.0",
+        "symlink-or-copy": "^1.1.8",
         "temp": "0.8.3",
-        "testem": "1.18.4",
-        "tiny-lr": "1.0.5",
-        "tree-sync": "1.2.2",
-        "uuid": "3.1.0",
-        "validate-npm-package-name": "3.0.0",
-        "walk-sync": "0.3.2",
+        "testem": "^1.18.0",
+        "tiny-lr": "^1.0.3",
+        "tree-sync": "^1.2.1",
+        "uuid": "^3.0.0",
+        "validate-npm-package-name": "^3.0.0",
+        "walk-sync": "^0.3.0",
         "yam": "0.0.22"
       },
       "dependencies": {
@@ -3650,7 +3645,7 @@
           "integrity": "sha1-Dlk7KNb6MyarF5gQftrqlhBG6Ng=",
           "dev": true,
           "requires": {
-            "ensure-posix-path": "1.0.2"
+            "ensure-posix-path": "^1.0.1"
           }
         },
         "ansi-styles": {
@@ -3659,7 +3654,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3668,9 +3663,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "glob": {
@@ -3679,12 +3674,12 @@
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "rsvp": {
@@ -3699,7 +3694,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3710,8 +3705,8 @@
       "integrity": "sha512-Y8itgYxAZ0kBzgu8yCrrEuHvbW6sHkojZofkg3AsAC+hwc6wdJ65hQULR3JhhGB1AcId0Xs7xu6EBYIr7B06Fw==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.11.0",
-        "git-repo-version": "1.0.1"
+        "ember-cli-babel": "^6.8.0",
+        "git-repo-version": "^1.0.0"
       }
     },
     "ember-cli-babel": {
@@ -3720,18 +3715,18 @@
       "integrity": "sha512-lHQyl30lbAsMmMq2it1GO85HKrqr2gMpK5CFxmOgTJ3moBqOGMKsdV3Z0qXWpgh8Asy7pB9AACMShdgfQvSGPg==",
       "requires": {
         "amd-name-resolver": "0.0.7",
-        "babel-plugin-debug-macros": "0.1.11",
-        "babel-plugin-ember-modules-api-polyfill": "2.3.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-polyfill": "6.26.0",
-        "babel-preset-env": "1.6.1",
-        "broccoli-babel-transpiler": "6.1.2",
-        "broccoli-debug": "0.6.4",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-source": "1.1.0",
-        "clone": "2.1.1",
-        "ember-cli-version-checker": "2.1.0",
-        "semver": "5.4.1"
+        "babel-plugin-debug-macros": "^0.1.11",
+        "babel-plugin-ember-modules-api-polyfill": "^2.3.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+        "babel-polyfill": "^6.16.0",
+        "babel-preset-env": "^1.5.1",
+        "broccoli-babel-transpiler": "^6.1.2",
+        "broccoli-debug": "^0.6.2",
+        "broccoli-funnel": "^1.0.0",
+        "broccoli-source": "^1.1.0",
+        "clone": "^2.0.0",
+        "ember-cli-version-checker": "^2.1.0",
+        "semver": "^5.4.1"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -3739,20 +3734,20 @@
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           }
         }
       }
@@ -3763,11 +3758,11 @@
       "integrity": "sha1-9D9C91t1CcIS+5Js2a6oauGSZMY=",
       "dev": true,
       "requires": {
-        "broccoli-slow-trees": "3.0.1",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "rsvp": "3.6.2",
-        "sane": "1.7.0"
+        "broccoli-slow-trees": "^3.0.1",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "rsvp": "^3.0.18",
+        "sane": "^1.1.1"
       }
     },
     "ember-cli-build-config-editor": {
@@ -3776,7 +3771,7 @@
       "integrity": "sha1-4ZoG9NouPlebQHlkty35+/ODn0s=",
       "dev": true,
       "requires": {
-        "recast": "0.12.9"
+        "recast": "^0.12.0"
       }
     },
     "ember-cli-code-coverage": {
@@ -3785,23 +3780,23 @@
       "integrity": "sha1-vSI69FPvC4DlSCzJlYzZcmtYZcc=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "body-parser": "1.18.2",
-        "broccoli-filter": "1.2.4",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "ember-cli-babel": "6.11.0",
-        "escodegen": "1.9.0",
-        "esprima": "3.1.3",
+        "babel-core": "^6.24.1",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "body-parser": "^1.15.0",
+        "broccoli-filter": "^1.2.3",
+        "broccoli-funnel": "^1.0.1",
+        "broccoli-merge-trees": "^1.1.1",
+        "ember-cli-babel": "^6.8.2",
+        "escodegen": "^1.8.0",
+        "esprima": "^3.1.3",
         "exists-sync": "0.0.3",
-        "extend": "3.0.1",
-        "fs-extra": "0.26.7",
-        "istanbul": "0.4.5",
-        "node-dir": "0.1.17",
-        "rsvp": "3.6.2",
+        "extend": "^3.0.0",
+        "fs-extra": "^0.26.7",
+        "istanbul": "^0.4.3",
+        "node-dir": "^0.1.16",
+        "rsvp": "^3.2.1",
         "source-map": "0.5.6",
-        "string.prototype.startswith": "0.2.0"
+        "string.prototype.startswith": "^0.2.0"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -3810,20 +3805,20 @@
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "exists-sync": {
@@ -3840,14 +3835,14 @@
           "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
           "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-plugin": "^1.3.0",
+            "can-symlink": "^1.0.0",
+            "fast-ordered-set": "^1.0.2",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
           }
         },
         "esprima": {
@@ -3868,11 +3863,11 @@
           "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "source-map": {
@@ -3889,10 +3884,10 @@
       "integrity": "sha1-nWYoanx3jpRzPq8hMg0SnE/Q3WQ=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "is-git-url": "1.0.0",
-        "resolve": "1.5.0",
-        "semver": "5.4.1"
+        "chalk": "^1.1.3",
+        "is-git-url": "^1.0.0",
+        "resolve": "^1.5.0",
+        "semver": "^5.3.0"
       }
     },
     "ember-cli-eslint": {
@@ -3901,10 +3896,10 @@
       "integrity": "sha512-1fqRz9QVLTT790Zr07aDFmAprZ1vVsaBGJOGQgDEFmBpogq8BeaQopaxogWFp748hol8nGC4QP5tbzhVD6KQHw==",
       "dev": true,
       "requires": {
-        "broccoli-lint-eslint": "4.2.1",
-        "ember-cli-version-checker": "2.1.0",
-        "rsvp": "4.7.0",
-        "walk-sync": "0.3.2"
+        "broccoli-lint-eslint": "^4.2.1",
+        "ember-cli-version-checker": "^2.1.0",
+        "rsvp": "^4.6.1",
+        "walk-sync": "^0.3.0"
       },
       "dependencies": {
         "rsvp": {
@@ -3921,21 +3916,21 @@
       "integrity": "sha512-hctBX1MQYTDjYF2ISR6qZIT+fY4mmJFwCskNM/ruHTmN0XKgSSvRijRfF9y/VgpDux77iEDMNT9C5ZIzhSFEoA==",
       "dev": true,
       "requires": {
-        "broccoli-concat": "3.2.2",
-        "broccoli-funnel": "2.0.1",
-        "broccoli-merge-trees": "2.0.0",
-        "broccoli-plugin": "1.3.0",
-        "chalk": "2.3.0",
-        "ember-cli-babel": "6.11.0",
+        "broccoli-concat": "^3.2.2",
+        "broccoli-funnel": "^2.0.0",
+        "broccoli-merge-trees": "^2.0.0",
+        "broccoli-plugin": "^1.2.1",
+        "chalk": "^2.0.1",
+        "ember-cli-babel": "^6.7.2",
         "ember-cli-lodash-subset": "2.0.1",
-        "ember-cli-version-checker": "2.1.0",
-        "fastboot": "1.1.2",
-        "fastboot-express-middleware": "1.1.1",
-        "fastboot-transform": "0.1.2",
-        "fs-extra": "4.0.3",
-        "json-stable-stringify": "1.0.1",
-        "md5-hex": "2.0.0",
-        "silent-error": "1.1.0"
+        "ember-cli-version-checker": "^2.0.0",
+        "fastboot": "^1.1.0",
+        "fastboot-express-middleware": "^1.1.0",
+        "fastboot-transform": "^0.1.2",
+        "fs-extra": "^4.0.2",
+        "json-stable-stringify": "^1.0.1",
+        "md5-hex": "^2.0.0",
+        "silent-error": "^1.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3944,7 +3939,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3953,9 +3948,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -3964,7 +3959,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3976,9 +3971,9 @@
       "dev": true,
       "requires": {
         "broccoli-favicon": "1.0.0",
-        "broccoli-merge-trees": "1.2.4",
-        "broccoli-replace": "0.12.0",
-        "ember-cli-babel": "5.2.4"
+        "broccoli-merge-trees": "^1.1.1",
+        "broccoli-replace": "^0.12.0",
+        "ember-cli-babel": "^5.1.6"
       },
       "dependencies": {
         "babel-core": {
@@ -3987,52 +3982,52 @@
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
           "dev": true,
           "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "1.5.1",
-            "core-js": "1.2.7",
-            "debug": "2.6.9",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
+            "babel-plugin-constant-folding": "^1.0.1",
+            "babel-plugin-dead-code-elimination": "^1.0.2",
+            "babel-plugin-eval": "^1.0.1",
+            "babel-plugin-inline-environment-variables": "^1.0.1",
+            "babel-plugin-jscript": "^1.0.4",
+            "babel-plugin-member-expression-literals": "^1.0.1",
+            "babel-plugin-property-literals": "^1.0.1",
+            "babel-plugin-proto-to-assign": "^1.0.3",
+            "babel-plugin-react-constant-elements": "^1.0.3",
+            "babel-plugin-react-display-name": "^1.0.3",
+            "babel-plugin-remove-console": "^1.0.1",
+            "babel-plugin-remove-debugger": "^1.0.1",
+            "babel-plugin-runtime": "^1.0.7",
+            "babel-plugin-undeclared-variables-check": "^1.0.2",
+            "babel-plugin-undefined-to-void": "^1.1.6",
+            "babylon": "^5.8.38",
+            "bluebird": "^2.9.33",
+            "chalk": "^1.0.0",
+            "convert-source-map": "^1.1.0",
+            "core-js": "^1.0.0",
+            "debug": "^2.1.1",
+            "detect-indent": "^3.0.0",
+            "esutils": "^2.0.0",
+            "fs-readdir-recursive": "^0.1.0",
+            "globals": "^6.4.0",
+            "home-or-tmp": "^1.0.0",
+            "is-integer": "^1.0.4",
             "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.8",
+            "json5": "^0.4.0",
+            "lodash": "^3.10.0",
+            "minimatch": "^2.0.3",
+            "output-file-sync": "^1.1.0",
+            "path-exists": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "private": "^0.1.6",
             "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "1.5.0",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "0.5.7",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
+            "regexpu": "^1.3.0",
+            "repeating": "^1.1.2",
+            "resolve": "^1.1.6",
+            "shebang-regex": "^1.0.0",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.0",
+            "source-map-support": "^0.2.10",
+            "to-fast-properties": "^1.0.0",
+            "trim-right": "^1.0.0",
+            "try-resolve": "^1.0.0"
           }
         },
         "babylon": {
@@ -4047,16 +4042,16 @@
           "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
           "dev": true,
           "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "1.4.3",
-            "clone": "0.2.0",
-            "hash-for-dep": "1.2.3",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "2.3.0"
+            "babel-core": "^5.0.0",
+            "broccoli-funnel": "^1.0.0",
+            "broccoli-merge-trees": "^1.0.0",
+            "broccoli-persistent-filter": "^1.4.2",
+            "clone": "^0.2.0",
+            "hash-for-dep": "^1.0.2",
+            "heimdalljs-logger": "^0.1.7",
+            "json-stable-stringify": "^1.0.0",
+            "rsvp": "^3.5.0",
+            "workerpool": "^2.2.1"
           },
           "dependencies": {
             "clone": {
@@ -4073,20 +4068,20 @@
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "minimatch": {
@@ -4095,7 +4090,7 @@
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
               }
             }
           }
@@ -4106,14 +4101,14 @@
           "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
           "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-plugin": "^1.3.0",
+            "can-symlink": "^1.0.0",
+            "fast-ordered-set": "^1.0.2",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
           }
         },
         "core-js": {
@@ -4128,9 +4123,9 @@
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
+            "get-stdin": "^4.0.1",
+            "minimist": "^1.1.0",
+            "repeating": "^1.1.0"
           }
         },
         "ember-cli-babel": {
@@ -4139,11 +4134,11 @@
           "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
           "dev": true,
           "requires": {
-            "broccoli-babel-transpiler": "5.7.2",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "1.3.1",
-            "resolve": "1.5.0"
+            "broccoli-babel-transpiler": "^5.6.2",
+            "broccoli-funnel": "^1.0.0",
+            "clone": "^2.0.0",
+            "ember-cli-version-checker": "^1.0.2",
+            "resolve": "^1.1.2"
           }
         },
         "ember-cli-version-checker": {
@@ -4152,7 +4147,7 @@
           "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
           "dev": true,
           "requires": {
-            "semver": "5.4.1"
+            "semver": "^5.3.0"
           }
         },
         "globals": {
@@ -4167,8 +4162,8 @@
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
+            "os-tmpdir": "^1.0.1",
+            "user-home": "^1.1.1"
           }
         },
         "js-tokens": {
@@ -4195,7 +4190,7 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.0.0"
           }
         },
         "minimist": {
@@ -4210,7 +4205,7 @@
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "source-map-support": {
@@ -4228,7 +4223,7 @@
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -4253,9 +4248,9 @@
       "integrity": "sha512-tDO93QlSW2Og//glMbPAnfpKUjS4dvHkPVUIZoRDUt1LCKtBboXUj2EkjxkvrWMghyGr4CQHdGTeK7xmISxVDw==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "5.2.4",
-        "ember-cli-version-checker": "1.3.1",
-        "rsvp": "3.6.2"
+        "ember-cli-babel": "^5.1.3",
+        "ember-cli-version-checker": "^1.1.6",
+        "rsvp": "^3.0.14"
       },
       "dependencies": {
         "babel-core": {
@@ -4264,52 +4259,52 @@
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
           "dev": true,
           "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "1.5.1",
-            "core-js": "1.2.7",
-            "debug": "2.6.9",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
+            "babel-plugin-constant-folding": "^1.0.1",
+            "babel-plugin-dead-code-elimination": "^1.0.2",
+            "babel-plugin-eval": "^1.0.1",
+            "babel-plugin-inline-environment-variables": "^1.0.1",
+            "babel-plugin-jscript": "^1.0.4",
+            "babel-plugin-member-expression-literals": "^1.0.1",
+            "babel-plugin-property-literals": "^1.0.1",
+            "babel-plugin-proto-to-assign": "^1.0.3",
+            "babel-plugin-react-constant-elements": "^1.0.3",
+            "babel-plugin-react-display-name": "^1.0.3",
+            "babel-plugin-remove-console": "^1.0.1",
+            "babel-plugin-remove-debugger": "^1.0.1",
+            "babel-plugin-runtime": "^1.0.7",
+            "babel-plugin-undeclared-variables-check": "^1.0.2",
+            "babel-plugin-undefined-to-void": "^1.1.6",
+            "babylon": "^5.8.38",
+            "bluebird": "^2.9.33",
+            "chalk": "^1.0.0",
+            "convert-source-map": "^1.1.0",
+            "core-js": "^1.0.0",
+            "debug": "^2.1.1",
+            "detect-indent": "^3.0.0",
+            "esutils": "^2.0.0",
+            "fs-readdir-recursive": "^0.1.0",
+            "globals": "^6.4.0",
+            "home-or-tmp": "^1.0.0",
+            "is-integer": "^1.0.4",
             "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.8",
+            "json5": "^0.4.0",
+            "lodash": "^3.10.0",
+            "minimatch": "^2.0.3",
+            "output-file-sync": "^1.1.0",
+            "path-exists": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "private": "^0.1.6",
             "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "1.5.0",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "0.5.7",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
+            "regexpu": "^1.3.0",
+            "repeating": "^1.1.2",
+            "resolve": "^1.1.6",
+            "shebang-regex": "^1.0.0",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.0",
+            "source-map-support": "^0.2.10",
+            "to-fast-properties": "^1.0.0",
+            "trim-right": "^1.0.0",
+            "try-resolve": "^1.0.0"
           }
         },
         "babylon": {
@@ -4324,16 +4319,16 @@
           "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
           "dev": true,
           "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "1.4.3",
-            "clone": "0.2.0",
-            "hash-for-dep": "1.2.3",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "2.3.0"
+            "babel-core": "^5.0.0",
+            "broccoli-funnel": "^1.0.0",
+            "broccoli-merge-trees": "^1.0.0",
+            "broccoli-persistent-filter": "^1.4.2",
+            "clone": "^0.2.0",
+            "hash-for-dep": "^1.0.2",
+            "heimdalljs-logger": "^0.1.7",
+            "json-stable-stringify": "^1.0.0",
+            "rsvp": "^3.5.0",
+            "workerpool": "^2.2.1"
           },
           "dependencies": {
             "clone": {
@@ -4350,20 +4345,20 @@
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "minimatch": {
@@ -4372,7 +4367,7 @@
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
               }
             }
           }
@@ -4383,14 +4378,14 @@
           "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
           "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-plugin": "^1.3.0",
+            "can-symlink": "^1.0.0",
+            "fast-ordered-set": "^1.0.2",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
           }
         },
         "core-js": {
@@ -4405,9 +4400,9 @@
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
+            "get-stdin": "^4.0.1",
+            "minimist": "^1.1.0",
+            "repeating": "^1.1.0"
           }
         },
         "ember-cli-babel": {
@@ -4416,11 +4411,11 @@
           "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
           "dev": true,
           "requires": {
-            "broccoli-babel-transpiler": "5.7.2",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "1.3.1",
-            "resolve": "1.5.0"
+            "broccoli-babel-transpiler": "^5.6.2",
+            "broccoli-funnel": "^1.0.0",
+            "clone": "^2.0.0",
+            "ember-cli-version-checker": "^1.0.2",
+            "resolve": "^1.1.2"
           }
         },
         "ember-cli-version-checker": {
@@ -4429,7 +4424,7 @@
           "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
           "dev": true,
           "requires": {
-            "semver": "5.4.1"
+            "semver": "^5.3.0"
           }
         },
         "globals": {
@@ -4444,8 +4439,8 @@
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
+            "os-tmpdir": "^1.0.1",
+            "user-home": "^1.1.1"
           }
         },
         "js-tokens": {
@@ -4472,7 +4467,7 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.0.0"
           }
         },
         "minimist": {
@@ -4487,7 +4482,7 @@
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "source-map-support": {
@@ -4505,7 +4500,7 @@
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -4518,10 +4513,10 @@
       "integrity": "sha512-oyWtJebOwxAqWZwMc0NKFJ8FJdxVixM7zl0FaXq1vTAG6bOgnU7yAhXEASlaO5f+PptZueZfOpdpvRwZW/Gk1A==",
       "dev": true,
       "requires": {
-        "broccoli-persistent-filter": "1.4.3",
-        "hash-for-dep": "1.2.3",
-        "json-stable-stringify": "1.0.1",
-        "strip-bom": "3.0.0"
+        "broccoli-persistent-filter": "^1.0.3",
+        "hash-for-dep": "^1.0.2",
+        "json-stable-stringify": "^1.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "ember-cli-htmlbars-inline-precompile": {
@@ -4530,11 +4525,11 @@
       "integrity": "sha1-W1RPZk1dmRHwjNl5xfcNjLDKKt0=",
       "dev": true,
       "requires": {
-        "babel-plugin-htmlbars-inline-precompile": "0.2.3",
-        "ember-cli-version-checker": "2.1.0",
-        "hash-for-dep": "1.2.3",
-        "heimdalljs-logger": "0.1.9",
-        "silent-error": "1.1.0"
+        "babel-plugin-htmlbars-inline-precompile": "^0.2.3",
+        "ember-cli-version-checker": "^2.0.0",
+        "hash-for-dep": "^1.0.2",
+        "heimdalljs-logger": "^0.1.7",
+        "silent-error": "^1.1.0"
       }
     },
     "ember-cli-inject-live-reload": {
@@ -4555,23 +4550,23 @@
       "integrity": "sha1-k8FcokLsUQfWKor37DD2rFOPOtk=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "ember-cli-get-component-path-option": "1.0.0",
-        "ember-cli-get-dependency-depth": "1.0.0",
-        "ember-cli-is-package-missing": "1.0.0",
-        "ember-cli-lodash-subset": "1.0.12",
-        "ember-cli-normalize-entity-name": "1.0.0",
-        "ember-cli-path-utils": "1.0.0",
-        "ember-cli-string-utils": "1.1.0",
-        "ember-cli-test-info": "1.0.0",
-        "ember-cli-valid-component-name": "1.0.0",
-        "ember-cli-version-checker": "1.3.1",
-        "ember-router-generator": "1.2.3",
+        "chalk": "^1.1.1",
+        "ember-cli-get-component-path-option": "^1.0.0",
+        "ember-cli-get-dependency-depth": "^1.0.0",
+        "ember-cli-is-package-missing": "^1.0.0",
+        "ember-cli-lodash-subset": "^1.0.7",
+        "ember-cli-normalize-entity-name": "^1.0.0",
+        "ember-cli-path-utils": "^1.0.0",
+        "ember-cli-string-utils": "^1.0.0",
+        "ember-cli-test-info": "^1.0.0",
+        "ember-cli-valid-component-name": "^1.0.0",
+        "ember-cli-version-checker": "^1.1.7",
+        "ember-router-generator": "^1.0.0",
         "exists-sync": "0.0.3",
-        "fs-extra": "0.24.0",
-        "inflection": "1.12.0",
-        "rsvp": "3.6.2",
-        "silent-error": "1.1.0"
+        "fs-extra": "^0.24.0",
+        "inflection": "^1.7.1",
+        "rsvp": "^3.0.17",
+        "silent-error": "^1.0.0"
       },
       "dependencies": {
         "ember-cli-lodash-subset": {
@@ -4586,7 +4581,7 @@
           "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
           "dev": true,
           "requires": {
-            "semver": "5.4.1"
+            "semver": "^5.3.0"
           }
         },
         "exists-sync": {
@@ -4601,10 +4596,10 @@
           "integrity": "sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         }
       }
@@ -4621,12 +4616,12 @@
       "integrity": "sha1-0tVWJufMZhn4gtf+VXUfkmYCJwg=",
       "dev": true,
       "requires": {
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "broccoli-source": "1.1.0",
-        "debug": "2.6.9",
-        "lodash": "4.17.4",
-        "resolve": "1.5.0"
+        "broccoli-funnel": "^1.0.1",
+        "broccoli-merge-trees": "^1.1.1",
+        "broccoli-source": "^1.1.0",
+        "debug": "^2.2.0",
+        "lodash": "^4.5.1",
+        "resolve": "^1.1.7"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -4635,20 +4630,20 @@
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           }
         },
         "broccoli-merge-trees": {
@@ -4657,14 +4652,14 @@
           "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
           "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-plugin": "^1.3.0",
+            "can-symlink": "^1.0.0",
+            "fast-ordered-set": "^1.0.2",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
           }
         }
       }
@@ -4675,7 +4670,7 @@
       "integrity": "sha1-CxT3vLxZmqEXtf3cgeT9A8S61bc=",
       "dev": true,
       "requires": {
-        "silent-error": "1.1.0"
+        "silent-error": "^1.0.0"
       }
     },
     "ember-cli-path-utils": {
@@ -4690,14 +4685,14 @@
       "integrity": "sha1-OEVsIcTStklFhQz57Gjba6dpKIo=",
       "dev": true,
       "requires": {
-        "broccoli-clean-css": "1.1.0",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "debug": "2.6.9",
-        "ember-cli-lodash-subset": "1.0.12",
+        "broccoli-clean-css": "^1.1.0",
+        "broccoli-funnel": "^1.0.0",
+        "broccoli-merge-trees": "^1.0.0",
+        "debug": "^2.2.0",
+        "ember-cli-lodash-subset": "^1.0.7",
         "exists-sync": "0.0.3",
-        "process-relative-require": "1.0.0",
-        "silent-error": "1.1.0"
+        "process-relative-require": "^1.0.0",
+        "silent-error": "^1.0.0"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -4706,20 +4701,20 @@
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "exists-sync": {
@@ -4736,14 +4731,14 @@
           "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
           "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-plugin": "^1.3.0",
+            "can-symlink": "^1.0.0",
+            "fast-ordered-set": "^1.0.2",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
           }
         },
         "ember-cli-lodash-subset": {
@@ -4766,8 +4761,8 @@
       "integrity": "sha1-iVgObrFX7pi57vvUj7qbt16mRUQ=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.11.0",
-        "ember-qunit": "3.2.2"
+        "ember-cli-babel": "^6.8.1",
+        "ember-qunit": "^3.2.2"
       }
     },
     "ember-cli-release": {
@@ -4776,17 +4771,17 @@
       "integrity": "sha1-y3LTQSk+lKGovPS3P3pjlvW34MU=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "git-tools": "0.1.4",
-        "make-array": "0.1.2",
-        "merge": "1.2.0",
-        "moment-timezone": "0.3.1",
-        "nopt": "3.0.6",
-        "npm": "3.5.4",
-        "require-dir": "0.3.2",
-        "rsvp": "3.6.2",
-        "semver": "4.3.6",
-        "silent-error": "1.1.0"
+        "chalk": "^1.0.0",
+        "git-tools": "^0.1.4",
+        "make-array": "^0.1.2",
+        "merge": "^1.2.0",
+        "moment-timezone": "^0.3.0",
+        "nopt": "^3.0.3",
+        "npm": "~3.5.2",
+        "require-dir": "^0.3.0",
+        "rsvp": "^3.0.17",
+        "semver": "^4.3.1",
+        "silent-error": "^1.0.0"
       },
       "dependencies": {
         "semver": {
@@ -4803,11 +4798,11 @@
       "integrity": "sha512-cBNSZlP8TsExKqAsL1DqTNsKuwlahGbGCCPRS3hfRX/c/TDt1oUjCgyV5XyiJDEtw9e/qikKEF8TcPie4NHbvg==",
       "dev": true,
       "requires": {
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "broccoli-sass-source-maps": "2.1.1",
-        "ember-cli-babel": "6.11.0",
-        "ember-cli-version-checker": "1.3.1"
+        "broccoli-funnel": "^1.0.0",
+        "broccoli-merge-trees": "^1.1.0",
+        "broccoli-sass-source-maps": "^2.1.0",
+        "ember-cli-babel": "^6.6.0",
+        "ember-cli-version-checker": "^1.0.2"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -4816,20 +4811,20 @@
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           }
         },
         "broccoli-merge-trees": {
@@ -4838,14 +4833,14 @@
           "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
           "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-plugin": "^1.3.0",
+            "can-symlink": "^1.0.0",
+            "fast-ordered-set": "^1.0.2",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
           }
         },
         "ember-cli-version-checker": {
@@ -4854,7 +4849,7 @@
           "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
           "dev": true,
           "requires": {
-            "semver": "5.4.1"
+            "semver": "^5.3.0"
           }
         }
       }
@@ -4865,11 +4860,11 @@
       "integrity": "sha1-D1Ov8Kq4C18p2jqXMbrFYWndlB8=",
       "dev": true,
       "requires": {
-        "broccoli-file-creator": "1.1.1",
-        "broccoli-merge-trees": "2.0.0",
-        "ember-cli-version-checker": "2.1.0",
-        "ember-rfc176-data": "0.3.1",
-        "silent-error": "1.1.0"
+        "broccoli-file-creator": "^1.1.1",
+        "broccoli-merge-trees": "^2.0.0",
+        "ember-cli-version-checker": "^2.0.0",
+        "ember-rfc176-data": "^0.3.1",
+        "silent-error": "^1.0.1"
       }
     },
     "ember-cli-sri": {
@@ -4878,7 +4873,7 @@
       "integrity": "sha1-lxYgk0pLkYPPeSPMA+F4uDqpB/0=",
       "dev": true,
       "requires": {
-        "broccoli-sri-hash": "2.1.2"
+        "broccoli-sri-hash": "^2.1.0"
       }
     },
     "ember-cli-string-utils": {
@@ -4893,7 +4888,7 @@
       "integrity": "sha1-7U6WDySel1I8+JHkrtIHLOhFd7Q=",
       "dev": true,
       "requires": {
-        "ember-cli-string-utils": "1.1.0"
+        "ember-cli-string-utils": "^1.0.0"
       }
     },
     "ember-cli-test-loader": {
@@ -4902,7 +4897,7 @@
       "integrity": "sha512-mlSXX9SciIRwGkFTX6XGyJYp4ry6oCFZRxh5jJ7VH8UXLTNx2ZACtDTwaWtNhYrWXgKyiDUvmD8enD56aePWRA==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.11.0"
+        "ember-cli-babel": "^6.8.1"
       }
     },
     "ember-cli-uglify": {
@@ -4911,8 +4906,8 @@
       "integrity": "sha1-sJZyfX0XGKzJv+XRvIHOJsr99so=",
       "dev": true,
       "requires": {
-        "broccoli-uglify-sourcemap": "2.0.1",
-        "lodash.defaultsdeep": "4.6.0"
+        "broccoli-uglify-sourcemap": "^2.0.0",
+        "lodash.defaultsdeep": "^4.6.0"
       }
     },
     "ember-cli-valid-component-name": {
@@ -4921,7 +4916,7 @@
       "integrity": "sha1-cVUM44fgIzBl8wswsVEKot++h+8=",
       "dev": true,
       "requires": {
-        "silent-error": "1.1.0"
+        "silent-error": "^1.0.0"
       }
     },
     "ember-cli-version-checker": {
@@ -4929,8 +4924,8 @@
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
       "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
       "requires": {
-        "resolve": "1.5.0",
-        "semver": "5.4.1"
+        "resolve": "^1.3.3",
+        "semver": "^5.3.0"
       }
     },
     "ember-compatibility-helpers": {
@@ -4939,9 +4934,9 @@
       "integrity": "sha512-3YBCYrbZ+HqQRSxbGl9jso1FBX6WjGS9FC7tgmmul3us6vtFPxjjnGN25H5ze2xk/mDCG373p0lm5xG+mVpKkA==",
       "dev": true,
       "requires": {
-        "babel-plugin-debug-macros": "0.1.11",
-        "ember-cli-version-checker": "2.1.0",
-        "semver": "5.4.1"
+        "babel-plugin-debug-macros": "^0.1.11",
+        "ember-cli-version-checker": "^2.0.0",
+        "semver": "^5.4.1"
       }
     },
     "ember-data": {
@@ -4951,34 +4946,34 @@
       "dev": true,
       "requires": {
         "amd-name-resolver": "0.0.7",
-        "babel-plugin-ember-modules-api-polyfill": "1.6.0",
-        "babel-plugin-feature-flags": "0.3.1",
-        "babel-plugin-filter-imports": "0.3.1",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel6-plugin-strip-class-callcheck": "6.0.0",
-        "babel6-plugin-strip-heimdall": "6.0.1",
-        "broccoli-babel-transpiler": "6.1.2",
-        "broccoli-debug": "0.6.4",
-        "broccoli-file-creator": "1.1.1",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "2.0.0",
-        "broccoli-rollup": "1.3.0",
-        "calculate-cache-key-for-tree": "1.1.0",
-        "chalk": "1.1.3",
-        "ember-cli-babel": "6.11.0",
-        "ember-cli-path-utils": "1.0.0",
-        "ember-cli-string-utils": "1.1.0",
-        "ember-cli-test-info": "1.0.0",
-        "ember-cli-version-checker": "1.3.1",
-        "ember-inflector": "2.1.0",
-        "ember-runtime-enumerable-includes-polyfill": "2.1.0",
+        "babel-plugin-ember-modules-api-polyfill": "^1.4.2",
+        "babel-plugin-feature-flags": "^0.3.1",
+        "babel-plugin-filter-imports": "^0.3.1",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel6-plugin-strip-class-callcheck": "^6.0.0",
+        "babel6-plugin-strip-heimdall": "^6.0.1",
+        "broccoli-babel-transpiler": "^6.0.0",
+        "broccoli-debug": "^0.6.2",
+        "broccoli-file-creator": "^1.0.0",
+        "broccoli-funnel": "^1.2.0",
+        "broccoli-merge-trees": "^2.0.0",
+        "broccoli-rollup": "^1.2.0",
+        "calculate-cache-key-for-tree": "^1.1.0",
+        "chalk": "^1.1.1",
+        "ember-cli-babel": "^6.8.2",
+        "ember-cli-path-utils": "^1.0.0",
+        "ember-cli-string-utils": "^1.0.0",
+        "ember-cli-test-info": "^1.0.0",
+        "ember-cli-version-checker": "^1.1.4",
+        "ember-inflector": "^2.0.0",
+        "ember-runtime-enumerable-includes-polyfill": "^2.0.0",
         "exists-sync": "0.0.3",
-        "git-repo-info": "1.4.1",
-        "heimdalljs": "0.3.3",
-        "inflection": "1.12.0",
-        "npm-git-info": "1.0.3",
-        "semver": "5.4.1",
-        "silent-error": "1.1.0"
+        "git-repo-info": "^1.1.2",
+        "heimdalljs": "^0.3.0",
+        "inflection": "^1.8.0",
+        "npm-git-info": "^1.0.0",
+        "semver": "^5.1.0",
+        "silent-error": "^1.0.0"
       },
       "dependencies": {
         "babel-plugin-ember-modules-api-polyfill": {
@@ -4987,7 +4982,7 @@
           "integrity": "sha512-HIOU4QBiselFqEvx6QaKrS/zxnfRQygQyA8wGdVUd42zO26G0jUqbEr1IE/NkTAbP4zsF0sY/ZLtVpjYiVB3VQ==",
           "dev": true,
           "requires": {
-            "ember-rfc176-data": "0.2.7"
+            "ember-rfc176-data": "^0.2.0"
           }
         },
         "babel-plugin-filter-imports": {
@@ -5002,20 +4997,20 @@
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "exists-sync": {
@@ -5030,7 +5025,7 @@
               "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
               "dev": true,
               "requires": {
-                "rsvp": "3.2.1"
+                "rsvp": "~3.2.1"
               }
             }
           }
@@ -5041,7 +5036,7 @@
           "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
           "dev": true,
           "requires": {
-            "semver": "5.4.1"
+            "semver": "^5.3.0"
           }
         },
         "ember-rfc176-data": {
@@ -5062,7 +5057,7 @@
           "integrity": "sha1-6S0sb3f9RtW/ULYQ0orTF1UFTQs=",
           "dev": true,
           "requires": {
-            "rsvp": "3.2.1"
+            "rsvp": "~3.2.1"
           }
         },
         "rsvp": {
@@ -5079,12 +5074,12 @@
       "integrity": "sha512-i1rDZNPXozzd08+jA2oQDDIRa+Vbl4jbv1bmb4ciLVM2AdKvGS7470p2ixDgeilXTJL21BAGtv179DBMp6yy9Q==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-decorators-legacy": "1.3.4",
-        "ember-cli-babel": "6.11.0",
-        "ember-cli-version-checker": "2.1.0",
-        "ember-compatibility-helpers": "0.1.3",
-        "ember-macro-helpers": "0.16.3"
+        "babel-plugin-transform-class-properties": "^6.24.1",
+        "babel-plugin-transform-decorators-legacy": "^1.3.4",
+        "ember-cli-babel": "^6.0.0",
+        "ember-cli-version-checker": "^2.0.0",
+        "ember-compatibility-helpers": "^0.1.0",
+        "ember-macro-helpers": "^0.16.0"
       }
     },
     "ember-disable-prototype-extensions": {
@@ -5099,7 +5094,7 @@
       "integrity": "sha1-jW12GayKGj+MQwA1Sesh6+1oW9I=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.11.0"
+        "ember-cli-babel": "^6.0.0-beta.7"
       }
     },
     "ember-font-awesome": {
@@ -5108,11 +5103,11 @@
       "integrity": "sha1-9L1ezo42QXrj6nbKm8z8luUVTZo=",
       "dev": true,
       "requires": {
-        "broccoli-funnel": "1.2.0",
-        "chalk": "1.1.3",
-        "ember-cli-babel": "6.11.0",
-        "ember-cli-htmlbars": "2.0.3",
-        "font-awesome": "4.7.0"
+        "broccoli-funnel": "^1.2.0",
+        "chalk": "^1.1.3",
+        "ember-cli-babel": "^6.6.0",
+        "ember-cli-htmlbars": "^2.0.2",
+        "font-awesome": "^4.7.0"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -5121,20 +5116,20 @@
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           }
         }
       }
@@ -5145,8 +5140,8 @@
       "integrity": "sha1-EYSSoqA9c+RgBO13eSiUICH+Hs0=",
       "dev": true,
       "requires": {
-        "broccoli-file-creator": "1.1.1",
-        "ember-cli-babel": "6.11.0"
+        "broccoli-file-creator": "^1.1.1",
+        "ember-cli-babel": "^6.3.0"
       }
     },
     "ember-inflector": {
@@ -5155,7 +5150,7 @@
       "integrity": "sha512-o7X+MdPuMgH6GGP8JsZ6mr+WYiCcymzjPLr0ct2IUw4lh1EwVtmePuY6fBLuWmyQE1nJq4smDyNoOCE74n3f7g==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.11.0"
+        "ember-cli-babel": "^6.0.0"
       }
     },
     "ember-legacy-class-transform": {
@@ -5164,9 +5159,9 @@
       "integrity": "sha512-JDKXc7l94NyN2YO9slhSy/g+FDSUcxUjLoMWabdInVFWnlMYvx5pTdjEWvmq6Vu85mFx2JWPcWcOxKgcpb+QpQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-ember-legacy-class-constructor": "0.1.4",
-        "ember-cli-babel": "6.11.0",
-        "ember-cli-version-checker": "2.1.0"
+        "babel-plugin-ember-legacy-class-constructor": "^0.1.4",
+        "ember-cli-babel": "^6.3.0",
+        "ember-cli-version-checker": "^2.0.0"
       }
     },
     "ember-load-initializers": {
@@ -5175,7 +5170,7 @@
       "integrity": "sha1-SRnq8G9t/sp+E0Yz2MBabJkh5uc=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.11.0"
+        "ember-cli-babel": "^6.0.0-beta.7"
       }
     },
     "ember-macro-helpers": {
@@ -5184,10 +5179,10 @@
       "integrity": "sha1-OWAXHI4cGvS8NGnlVfwtRWnpbIA=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.11.0",
-        "ember-cli-string-utils": "1.1.0",
-        "ember-cli-test-info": "1.0.0",
-        "ember-weakmap": "2.0.0"
+        "ember-cli-babel": "^6.6.0",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-cli-test-info": "^1.0.0",
+        "ember-weakmap": "^2.0.0"
       }
     },
     "ember-popper": {
@@ -5196,20 +5191,20 @@
       "integrity": "sha512-10jCGmnZmMysZmoWybp7kxHY/1Tro2IzCjDWio+d1k+JqaEtqSFw/Zm4eU+YcdN8GHgbywwKT2jDWQs573IWqw==",
       "dev": true,
       "requires": {
-        "@ember-decorators/argument": "0.8.4",
-        "babel-eslint": "8.1.2",
-        "babel6-plugin-strip-class-callcheck": "6.0.0",
-        "broccoli-funnel": "2.0.1",
-        "ember-cli-babel": "6.11.0",
-        "ember-cli-htmlbars": "2.0.3",
-        "ember-cli-node-assets": "0.2.2",
-        "ember-cli-version-checker": "2.1.0",
-        "ember-compatibility-helpers": "0.1.3",
-        "ember-decorators": "1.3.2",
-        "ember-legacy-class-transform": "0.1.4",
-        "ember-raf-scheduler": "0.1.0",
-        "fastboot-transform": "0.1.2",
-        "popper.js": "1.12.9"
+        "@ember-decorators/argument": "^0.8.3",
+        "babel-eslint": "^8.0.3",
+        "babel6-plugin-strip-class-callcheck": "^6.0.0",
+        "broccoli-funnel": "^2.0.0",
+        "ember-cli-babel": "^6.10.0",
+        "ember-cli-htmlbars": "^2.0.3",
+        "ember-cli-node-assets": "^0.2.2",
+        "ember-cli-version-checker": "^2.1.0",
+        "ember-compatibility-helpers": "^0.1.3",
+        "ember-decorators": "^1.3.2",
+        "ember-legacy-class-transform": "^0.1.4",
+        "ember-raf-scheduler": "^0.1.0",
+        "fastboot-transform": "^0.1.0",
+        "popper.js": "^1.12.9"
       }
     },
     "ember-qunit": {
@@ -5218,13 +5213,13 @@
       "integrity": "sha512-KPbYeOdBe2N3APQ8geckRS6ns7Uoqz/LESSPYQ2e1VIhnFYfdQJC19Jk5g+RWioMxCHw8E8U+VdusibGfSuqVQ==",
       "dev": true,
       "requires": {
-        "@ember/test-helpers": "0.7.11",
-        "broccoli-funnel": "2.0.1",
-        "broccoli-merge-trees": "2.0.0",
-        "common-tags": "1.6.0",
-        "ember-cli-babel": "6.11.0",
-        "ember-cli-test-loader": "2.2.0",
-        "qunit": "2.4.1"
+        "@ember/test-helpers": "^0.7.9",
+        "broccoli-funnel": "^2.0.1",
+        "broccoli-merge-trees": "^2.0.0",
+        "common-tags": "^1.4.0",
+        "ember-cli-babel": "^6.3.0",
+        "ember-cli-test-loader": "^2.2.0",
+        "qunit": "^2.4.1"
       }
     },
     "ember-raf-scheduler": {
@@ -5233,7 +5228,7 @@
       "integrity": "sha1-oioC0jjDdEmSMcA6ucW5iHxyqFM=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.11.0"
+        "ember-cli-babel": "^6.6.0"
       }
     },
     "ember-resolver": {
@@ -5242,13 +5237,13 @@
       "integrity": "sha512-BX8yvFWIbrh1IVZmpIY/14WUb7nD8tQzT5s0aUG/Nwq2LVqD/uNAEPcsq0XS2gLvKawwDQEQN30ptcvJApQBhA==",
       "dev": true,
       "requires": {
-        "@glimmer/resolver": "0.4.2",
-        "babel-plugin-debug-macros": "0.1.11",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "2.0.0",
-        "ember-cli-babel": "6.11.0",
-        "ember-cli-version-checker": "2.1.0",
-        "resolve": "1.5.0"
+        "@glimmer/resolver": "^0.4.1",
+        "babel-plugin-debug-macros": "^0.1.10",
+        "broccoli-funnel": "^1.1.0",
+        "broccoli-merge-trees": "^2.0.0",
+        "ember-cli-babel": "^6.8.1",
+        "ember-cli-version-checker": "^2.0.0",
+        "resolve": "^1.3.3"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -5257,20 +5252,20 @@
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           }
         }
       }
@@ -5286,7 +5281,7 @@
       "integrity": "sha1-jtLKhv8yM2MSD8FCeBkeno8TFe4=",
       "dev": true,
       "requires": {
-        "recast": "0.11.23"
+        "recast": "^0.11.3"
       },
       "dependencies": {
         "ast-types": {
@@ -5308,9 +5303,9 @@
           "dev": true,
           "requires": {
             "ast-types": "0.9.6",
-            "esprima": "3.1.3",
-            "private": "0.1.8",
-            "source-map": "0.5.7"
+            "esprima": "~3.1.0",
+            "private": "~0.1.5",
+            "source-map": "~0.5.0"
           }
         }
       }
@@ -5321,8 +5316,8 @@
       "integrity": "sha512-au18iI8VbEDYn3jLFZzETnKN5ciPgCUxMRucEP3jkq7qZ6sE0FVKpWMPY/h9tTND3VOBJt6fgPpEBJoJVCUudg==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.11.0",
-        "ember-cli-version-checker": "2.1.0"
+        "ember-cli-babel": "^6.9.0",
+        "ember-cli-version-checker": "^2.1.0"
       }
     },
     "ember-source": {
@@ -5331,21 +5326,21 @@
       "integrity": "sha1-t4hx3Um9jWQrgBdt9Pr3/X0Fnaw=",
       "dev": true,
       "requires": {
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "2.0.0",
-        "ember-cli-get-component-path-option": "1.0.0",
-        "ember-cli-is-package-missing": "1.0.0",
-        "ember-cli-normalize-entity-name": "1.0.0",
-        "ember-cli-path-utils": "1.0.0",
-        "ember-cli-string-utils": "1.1.0",
-        "ember-cli-test-info": "1.0.0",
-        "ember-cli-valid-component-name": "1.0.0",
-        "ember-cli-version-checker": "2.1.0",
-        "ember-router-generator": "1.2.3",
-        "fs-extra": "4.0.3",
-        "inflection": "1.12.0",
-        "jquery": "3.2.1",
-        "resolve": "1.5.0"
+        "broccoli-funnel": "^1.2.0",
+        "broccoli-merge-trees": "^2.0.0",
+        "ember-cli-get-component-path-option": "^1.0.0",
+        "ember-cli-is-package-missing": "^1.0.0",
+        "ember-cli-normalize-entity-name": "^1.0.0",
+        "ember-cli-path-utils": "^1.0.0",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-cli-test-info": "^1.0.0",
+        "ember-cli-valid-component-name": "^1.0.0",
+        "ember-cli-version-checker": "^2.1.0",
+        "ember-router-generator": "^1.2.3",
+        "fs-extra": "^4.0.1",
+        "inflection": "^1.12.0",
+        "jquery": "^3.2.1",
+        "resolve": "^1.3.3"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -5354,20 +5349,20 @@
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           }
         }
       }
@@ -5378,18 +5373,18 @@
       "integrity": "sha512-5NKqlKCGWqTUWAA61/dchIFKG2loqEBcHHI4ZbCHToKdK82NTzWkifxryhmwzFE0c9MomvQ3Rza7yxVD5C9rMw==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-table2": "0.2.0",
-        "core-object": "1.1.0",
-        "debug": "2.6.9",
-        "ember-try-config": "2.2.0",
-        "extend": "3.0.1",
-        "fs-extra": "0.26.7",
-        "promise-map-series": "0.2.3",
-        "resolve": "1.5.0",
-        "rimraf": "2.6.2",
-        "rsvp": "3.6.2",
-        "semver": "5.4.1"
+        "chalk": "^1.0.0",
+        "cli-table2": "^0.2.0",
+        "core-object": "^1.1.0",
+        "debug": "^2.2.0",
+        "ember-try-config": "^2.2.0",
+        "extend": "^3.0.0",
+        "fs-extra": "^0.26.0",
+        "promise-map-series": "^0.2.1",
+        "resolve": "^1.1.6",
+        "rimraf": "^2.3.2",
+        "rsvp": "^3.0.17",
+        "semver": "^5.1.0"
       },
       "dependencies": {
         "core-object": {
@@ -5404,11 +5399,11 @@
           "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         }
       }
@@ -5419,10 +5414,10 @@
       "integrity": "sha1-a+CvbHGUmBPgKseTVk/dv4M2uAc=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4",
-        "node-fetch": "1.7.3",
-        "rsvp": "3.6.2",
-        "semver": "5.4.1"
+        "lodash": "^4.6.1",
+        "node-fetch": "^1.3.3",
+        "rsvp": "^3.2.1",
+        "semver": "^5.1.0"
       }
     },
     "ember-weakmap": {
@@ -5431,7 +5426,7 @@
       "integrity": "sha1-ccaBmov9Cwd64Xyh2QU/xdsG5Kw=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "5.2.4"
+        "ember-cli-babel": "^5.1.6"
       },
       "dependencies": {
         "babel-core": {
@@ -5440,52 +5435,52 @@
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
           "dev": true,
           "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "1.5.1",
-            "core-js": "1.2.7",
-            "debug": "2.6.9",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
+            "babel-plugin-constant-folding": "^1.0.1",
+            "babel-plugin-dead-code-elimination": "^1.0.2",
+            "babel-plugin-eval": "^1.0.1",
+            "babel-plugin-inline-environment-variables": "^1.0.1",
+            "babel-plugin-jscript": "^1.0.4",
+            "babel-plugin-member-expression-literals": "^1.0.1",
+            "babel-plugin-property-literals": "^1.0.1",
+            "babel-plugin-proto-to-assign": "^1.0.3",
+            "babel-plugin-react-constant-elements": "^1.0.3",
+            "babel-plugin-react-display-name": "^1.0.3",
+            "babel-plugin-remove-console": "^1.0.1",
+            "babel-plugin-remove-debugger": "^1.0.1",
+            "babel-plugin-runtime": "^1.0.7",
+            "babel-plugin-undeclared-variables-check": "^1.0.2",
+            "babel-plugin-undefined-to-void": "^1.1.6",
+            "babylon": "^5.8.38",
+            "bluebird": "^2.9.33",
+            "chalk": "^1.0.0",
+            "convert-source-map": "^1.1.0",
+            "core-js": "^1.0.0",
+            "debug": "^2.1.1",
+            "detect-indent": "^3.0.0",
+            "esutils": "^2.0.0",
+            "fs-readdir-recursive": "^0.1.0",
+            "globals": "^6.4.0",
+            "home-or-tmp": "^1.0.0",
+            "is-integer": "^1.0.4",
             "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.8",
+            "json5": "^0.4.0",
+            "lodash": "^3.10.0",
+            "minimatch": "^2.0.3",
+            "output-file-sync": "^1.1.0",
+            "path-exists": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "private": "^0.1.6",
             "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "1.5.0",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "0.5.7",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
+            "regexpu": "^1.3.0",
+            "repeating": "^1.1.2",
+            "resolve": "^1.1.6",
+            "shebang-regex": "^1.0.0",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.0",
+            "source-map-support": "^0.2.10",
+            "to-fast-properties": "^1.0.0",
+            "trim-right": "^1.0.0",
+            "try-resolve": "^1.0.0"
           }
         },
         "babylon": {
@@ -5500,16 +5495,16 @@
           "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
           "dev": true,
           "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "1.4.3",
-            "clone": "0.2.0",
-            "hash-for-dep": "1.2.3",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "2.3.0"
+            "babel-core": "^5.0.0",
+            "broccoli-funnel": "^1.0.0",
+            "broccoli-merge-trees": "^1.0.0",
+            "broccoli-persistent-filter": "^1.4.2",
+            "clone": "^0.2.0",
+            "hash-for-dep": "^1.0.2",
+            "heimdalljs-logger": "^0.1.7",
+            "json-stable-stringify": "^1.0.0",
+            "rsvp": "^3.5.0",
+            "workerpool": "^2.2.1"
           },
           "dependencies": {
             "clone": {
@@ -5526,20 +5521,20 @@
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
           "dev": true,
           "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
             "exists-sync": "0.0.4",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
           },
           "dependencies": {
             "minimatch": {
@@ -5548,7 +5543,7 @@
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
               }
             }
           }
@@ -5559,14 +5554,14 @@
           "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
           "dev": true,
           "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8"
+            "broccoli-plugin": "^1.3.0",
+            "can-symlink": "^1.0.0",
+            "fast-ordered-set": "^1.0.2",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
           }
         },
         "core-js": {
@@ -5581,9 +5576,9 @@
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
+            "get-stdin": "^4.0.1",
+            "minimist": "^1.1.0",
+            "repeating": "^1.1.0"
           }
         },
         "ember-cli-babel": {
@@ -5592,11 +5587,11 @@
           "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
           "dev": true,
           "requires": {
-            "broccoli-babel-transpiler": "5.7.2",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "1.3.1",
-            "resolve": "1.5.0"
+            "broccoli-babel-transpiler": "^5.6.2",
+            "broccoli-funnel": "^1.0.0",
+            "clone": "^2.0.0",
+            "ember-cli-version-checker": "^1.0.2",
+            "resolve": "^1.1.2"
           }
         },
         "ember-cli-version-checker": {
@@ -5605,7 +5600,7 @@
           "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
           "dev": true,
           "requires": {
-            "semver": "5.4.1"
+            "semver": "^5.3.0"
           }
         },
         "globals": {
@@ -5620,8 +5615,8 @@
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
+            "os-tmpdir": "^1.0.1",
+            "user-home": "^1.1.1"
           }
         },
         "js-tokens": {
@@ -5648,7 +5643,7 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.0.0"
           }
         },
         "minimist": {
@@ -5663,7 +5658,7 @@
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "source-map-support": {
@@ -5681,7 +5676,7 @@
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -5694,8 +5689,8 @@
       "integrity": "sha1-lo6A8JNJT0rtJm51CvpjkZxhOD0=",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "6.11.0",
-        "ember-cli-htmlbars": "2.0.3"
+        "ember-cli-babel": "^6.10.0",
+        "ember-cli-htmlbars": "^2.0.1"
       }
     },
     "encodeurl": {
@@ -5710,7 +5705,7 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.19"
+        "iconv-lite": "~0.4.13"
       }
     },
     "engine.io": {
@@ -5733,7 +5728,7 @@
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
           "dev": true,
           "requires": {
-            "mime-types": "2.1.17",
+            "mime-types": "~2.1.11",
             "negotiator": "0.6.1"
           }
         },
@@ -5845,8 +5840,8 @@
       "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
       "dev": true,
       "requires": {
-        "string-template": "0.2.1",
-        "xtend": "4.0.1"
+        "string-template": "~0.2.1",
+        "xtend": "~4.0.0"
       }
     },
     "error-ex": {
@@ -5855,7 +5850,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es5-ext": {
@@ -5864,8 +5859,8 @@
       "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "~3.1.1"
       }
     },
     "es6-iterator": {
@@ -5874,9 +5869,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -5885,12 +5880,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-promise": {
@@ -5905,11 +5900,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-iterator": "2.0.3",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -5918,8 +5913,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "escape-html": {
@@ -5939,11 +5934,11 @@
       "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
       "dev": true,
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.5.7"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.5.6"
       },
       "dependencies": {
         "esprima": {
@@ -5960,43 +5955,43 @@
       "integrity": "sha512-Ul6CSGRjKscEyg0X/EeNs7o2XdnbTEOD1OM8cTjmx85RPcBJQrEhZLevhuJZNAE/vS2iVl5Uhgiqf3h5uLMCJQ==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.3.0",
-        "concat-stream": "1.6.0",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.0.2",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.2",
-        "esquery": "1.0.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.1.0",
-        "ignore": "3.3.7",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.0.1",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.4.1",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.2",
-        "text-table": "0.2.0"
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.0.2",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.2",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^4.0.1",
+        "text-table": "~0.2.0"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -6017,7 +6012,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -6026,9 +6021,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "cli-cursor": {
@@ -6037,7 +6032,7 @@
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "debug": {
@@ -6055,9 +6050,9 @@
           "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
           "dev": true,
           "requires": {
-            "chardet": "0.4.2",
-            "iconv-lite": "0.4.19",
-            "tmp": "0.0.33"
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
           }
         },
         "globals": {
@@ -6072,20 +6067,20 @@
           "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.0.0",
-            "chalk": "2.3.0",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "2.1.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.4",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx-lite": "4.0.8",
-            "rx-lite-aggregates": "4.0.8",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           }
         },
         "mute-stream": {
@@ -6100,7 +6095,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "restore-cursor": {
@@ -6109,8 +6104,8 @@
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "strip-ansi": {
@@ -6119,7 +6114,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -6128,7 +6123,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         },
         "tmp": {
@@ -6137,7 +6132,7 @@
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2"
+            "os-tmpdir": "~1.0.2"
           }
         }
       }
@@ -6148,9 +6143,9 @@
       "integrity": "sha512-wPq2N96YQR2/Ob2LfuLQV8BEotHXxiFcuBiHikN8P+2VGzxBeuydafXy/pExuTsU2RHfPiSgyBHavKGy1DYdrQ==",
       "dev": true,
       "requires": {
-        "ember-rfc176-data": "0.2.7",
-        "require-folder-tree": "1.4.5",
-        "snake-case": "2.1.0"
+        "ember-rfc176-data": "^0.2.7",
+        "require-folder-tree": "^1.4.5",
+        "snake-case": "^2.1.0"
       },
       "dependencies": {
         "ember-rfc176-data": {
@@ -6167,8 +6162,8 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-visitor-keys": {
@@ -6183,8 +6178,8 @@
       "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.3.0",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.2.1",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -6199,7 +6194,7 @@
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -6208,8 +6203,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0",
+        "object-assign": "^4.0.1"
       }
     },
     "estraverse": {
@@ -6235,8 +6230,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "eventemitter3": {
@@ -6257,9 +6252,9 @@
       "integrity": "sha1-WNRB20bkDebR8w3lvgInhb2J4yg=",
       "dev": true,
       "requires": {
-        "is-obj": "1.0.1",
-        "object-assign": "4.1.1",
-        "spawn-sync": "1.0.15"
+        "is-obj": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "spawn-sync": "^1.0.11"
       }
     },
     "exec-sh": {
@@ -6268,7 +6263,7 @@
       "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "dev": true,
       "requires": {
-        "merge": "1.2.0"
+        "merge": "^1.1.3"
       }
     },
     "execa": {
@@ -6277,13 +6272,13 @@
       "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "exif-parser": {
@@ -6321,7 +6316,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -6330,7 +6325,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "expand-tilde": {
@@ -6339,7 +6334,7 @@
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.1"
       }
     },
     "express": {
@@ -6348,36 +6343,36 @@
       "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "~1.3.4",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.0",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.2",
+        "proxy-addr": "~2.0.2",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.1",
         "serve-static": "1.13.1",
         "setprototypeof": "1.1.0",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       }
     },
     "extend": {
@@ -6392,9 +6387,9 @@
       "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
-        "spawn-sync": "1.0.15",
-        "tmp": "0.0.29"
+        "extend": "^3.0.0",
+        "spawn-sync": "^1.0.15",
+        "tmp": "^0.0.29"
       },
       "dependencies": {
         "tmp": {
@@ -6403,7 +6398,7 @@
           "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2"
+            "os-tmpdir": "~1.0.1"
           }
         }
       }
@@ -6414,7 +6409,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extract-zip": {
@@ -6469,7 +6464,7 @@
       "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
       "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
       "requires": {
-        "blank-object": "1.0.2"
+        "blank-object": "^1.0.1"
       }
     },
     "fast-sourcemap-concat": {
@@ -6478,15 +6473,15 @@
       "integrity": "sha1-IvFOktc543kgM0N27IQzv2deqgQ=",
       "dev": true,
       "requires": {
-        "chalk": "0.5.1",
-        "fs-extra": "0.30.0",
-        "heimdalljs-logger": "0.1.9",
-        "memory-streams": "0.1.2",
-        "mkdirp": "0.5.1",
-        "rsvp": "3.6.2",
-        "source-map": "0.4.4",
-        "source-map-url": "0.3.0",
-        "sourcemap-validator": "1.0.6"
+        "chalk": "^0.5.1",
+        "fs-extra": "^0.30.0",
+        "heimdalljs-logger": "^0.1.7",
+        "memory-streams": "^0.1.0",
+        "mkdirp": "^0.5.0",
+        "rsvp": "^3.0.14",
+        "source-map": "^0.4.2",
+        "source-map-url": "^0.3.0",
+        "sourcemap-validator": "^1.0.5"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6507,11 +6502,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
           }
         },
         "fs-extra": {
@@ -6520,11 +6515,11 @@
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "has-ansi": {
@@ -6533,7 +6528,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.0"
           }
         },
         "source-map": {
@@ -6542,7 +6537,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "strip-ansi": {
@@ -6551,7 +6546,7 @@
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.1"
           }
         },
         "supports-color": {
@@ -6568,14 +6563,14 @@
       "integrity": "sha512-d04JsNuKCFmCZi7TuFKK6CR/XH/JInobMizAFPA4IRu2jUXcSBG63ZyqH7vWQa+BS27O2yDNXXzySgCz4iYMyA==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "cookie": "0.3.1",
-        "debug": "3.1.0",
+        "chalk": "^2.0.1",
+        "cookie": "^0.3.1",
+        "debug": "^3.0.0",
         "exists-sync": "0.0.4",
-        "najax": "1.0.3",
-        "rsvp": "4.7.0",
-        "simple-dom": "1.3.0",
-        "source-map-support": "0.5.0"
+        "najax": "^1.0.2",
+        "rsvp": "^4.7.0",
+        "simple-dom": "^1.0.0",
+        "source-map-support": "^0.5.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6584,7 +6579,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -6593,9 +6588,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "debug": {
@@ -6625,7 +6620,7 @@
           "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
           "dev": true,
           "requires": {
-            "source-map": "0.6.1"
+            "source-map": "^0.6.0"
           }
         },
         "supports-color": {
@@ -6634,7 +6629,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -6645,9 +6640,9 @@
       "integrity": "sha512-XAB7oVThwvN/v5uI8jWkdwpm/4mAREgTkEFfWyAIPWTw3/adrQQTGBESEo0gei3N3dwdYFafdKKjWBPW6WhkPA==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "fastboot": "1.1.2",
-        "request": "2.83.0"
+        "chalk": "^2.0.1",
+        "fastboot": "^1.1.2",
+        "request": "^2.81.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6656,7 +6651,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -6665,9 +6660,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -6676,7 +6671,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -6687,7 +6682,7 @@
       "integrity": "sha512-SU343Ca3XeiGHxSvycVb3062ejN68Go8OXcx4QWgUUMek43XRUr/LuU4ILSxAMvvHvhamsSQivysWBEO9ux4oA==",
       "dev": true,
       "requires": {
-        "broccoli-stew": "1.5.0"
+        "broccoli-stew": "^1.5.0"
       }
     },
     "favicons": {
@@ -6696,24 +6691,24 @@
       "integrity": "sha1-orE4AKs/7CcVvI8n+oQdA41HYeI=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "cheerio": "0.19.0",
-        "clone": "1.0.3",
-        "colors": "1.1.2",
-        "harmony-reflect": "1.5.1",
-        "image-size": "0.4.0",
-        "jimp": "0.2.28",
+        "async": "^1.5.0",
+        "cheerio": "^0.19.0",
+        "clone": "^1.0.2",
+        "colors": "^1.1.2",
+        "harmony-reflect": "^1.4.2",
+        "image-size": "^0.4.0",
+        "jimp": "^0.2.13",
         "jsontoxml": "0.0.11",
-        "merge-defaults": "0.2.1",
-        "mkdirp": "0.5.1",
-        "node-rest-client": "1.8.0",
-        "require-directory": "2.1.1",
-        "svg2png": "3.0.1",
-        "through2": "2.0.3",
-        "tinycolor2": "1.4.1",
-        "to-ico": "1.1.5",
-        "underscore": "1.8.3",
-        "vinyl": "1.2.0"
+        "merge-defaults": "^0.2.1",
+        "mkdirp": "^0.5.1",
+        "node-rest-client": "^1.5.1",
+        "require-directory": "^2.1.1",
+        "svg2png": "~3.0.1",
+        "through2": "^2.0.0",
+        "tinycolor2": "^1.1.2",
+        "to-ico": "^1.1.2",
+        "underscore": "^1.8.3",
+        "vinyl": "^1.1.0"
       },
       "dependencies": {
         "async": {
@@ -6736,7 +6731,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": "0.7.0"
+        "websocket-driver": ">=0.5.1"
       }
     },
     "fb-watchman": {
@@ -6745,7 +6740,7 @@
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "requires": {
-        "bser": "2.0.0"
+        "bser": "^2.0.0"
       }
     },
     "fd-slicer": {
@@ -6754,7 +6749,7 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "figures": {
@@ -6763,7 +6758,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -6772,8 +6767,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "file-type": {
@@ -6800,11 +6795,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "finalhandler": {
@@ -6814,12 +6809,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       }
     },
     "find-index": {
@@ -6834,7 +6829,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "findup-sync": {
@@ -6843,10 +6838,10 @@
       "integrity": "sha1-b35LV7buOkA3tEFOrt6j9Y9x4Ow=",
       "dev": true,
       "requires": {
-        "detect-file": "0.1.0",
-        "is-glob": "2.0.1",
-        "micromatch": "2.3.11",
-        "resolve-dir": "0.1.1"
+        "detect-file": "^0.1.0",
+        "is-glob": "^2.0.1",
+        "micromatch": "^2.3.7",
+        "resolve-dir": "^0.1.0"
       }
     },
     "fireworm": {
@@ -6855,11 +6850,11 @@
       "integrity": "sha1-zPIPeUHxCIg/zduZOD2+bhhhx1g=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
+        "async": "~0.2.9",
         "is-type": "0.0.1",
-        "lodash.debounce": "3.1.1",
-        "lodash.flatten": "3.0.2",
-        "minimatch": "3.0.4"
+        "lodash.debounce": "^3.1.1",
+        "lodash.flatten": "^3.0.2",
+        "minimatch": "^3.0.2"
       },
       "dependencies": {
         "async": {
@@ -6876,10 +6871,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "font-awesome": {
@@ -6894,7 +6889,7 @@
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
       "dev": true,
       "requires": {
-        "is-function": "1.0.1"
+        "is-function": "~1.0.0"
       }
     },
     "for-in": {
@@ -6909,7 +6904,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "forever-agent": {
@@ -6924,9 +6919,9 @@
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -6953,9 +6948,9 @@
       "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       },
       "dependencies": {
         "jsonfile": {
@@ -6964,7 +6959,7 @@
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           }
         }
       }
@@ -6980,10 +6975,10 @@
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
       "integrity": "sha512-dJwDX6NBH7IfdfFjZAdHCZ6fIKc8LwR7kzqUhYRFJuX4g9ctG/7cuqJuwegGQsyLEykp6Z4krq+yIFMQlt7d9Q==",
       "requires": {
-        "heimdalljs-logger": "0.1.9",
-        "object-assign": "4.1.1",
-        "path-posix": "1.0.0",
-        "symlink-or-copy": "1.1.8"
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
       }
     },
     "fs.realpath": {
@@ -6998,8 +6993,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -7014,14 +7009,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -7035,8 +7031,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "asn1": {
@@ -7072,7 +7068,8 @@
         "balanced-match": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -7080,38 +7077,42 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "~2.0.0"
           }
         },
         "boom": {
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "brace-expansion": {
           "version": "1.1.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -7128,37 +7129,43 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "dashdash": {
@@ -7167,7 +7174,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -7196,7 +7203,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -7216,7 +7224,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "extend": {
@@ -7228,7 +7236,8 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -7242,25 +7251,27 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "fstream-ignore": {
@@ -7269,9 +7280,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
+            "fstream": "^1.0.0",
+            "inherits": "2",
+            "minimatch": "^3.0.0"
           }
         },
         "gauge": {
@@ -7280,14 +7291,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "getpass": {
@@ -7296,7 +7307,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -7311,19 +7322,21 @@
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -7337,8 +7350,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "has-unicode": {
@@ -7351,17 +7364,19 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
           "version": "2.16.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -7369,24 +7384,26 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.4",
@@ -7398,8 +7415,9 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -7411,7 +7429,8 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -7425,7 +7444,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "jsbn": {
@@ -7446,7 +7465,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -7484,33 +7503,38 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "mime-db": "1.27.0"
+            "mime-db": "~1.27.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7527,17 +7551,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.2",
+            "detect-libc": "^1.0.2",
             "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
             "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^2.2.1",
+            "tar-pack": "^3.4.0"
           }
         },
         "nopt": {
@@ -7546,8 +7570,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npmlog": {
@@ -7556,16 +7580,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -7583,8 +7608,9 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -7605,14 +7631,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "performance-now": {
           "version": "0.2.0",
@@ -7623,7 +7650,8 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -7643,10 +7671,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -7661,14 +7689,15 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
         "request": {
@@ -7677,42 +7706,44 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
           }
         },
         "rimraf": {
           "version": "2.6.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -7736,8 +7767,9 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "sshpk": {
@@ -7746,15 +7778,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jodid25519": "^1.0.0",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -7769,18 +7801,20 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "stringstream": {
@@ -7793,8 +7827,9 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -7807,10 +7842,11 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         },
         "tar-pack": {
@@ -7819,14 +7855,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "debug": "^2.2.0",
+            "fstream": "^1.0.10",
+            "fstream-ignore": "^1.0.5",
+            "once": "^1.3.3",
+            "readable-stream": "^2.1.4",
+            "rimraf": "^2.5.1",
+            "tar": "^2.2.1",
+            "uid-number": "^0.0.6"
           }
         },
         "tough-cookie": {
@@ -7835,7 +7871,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
@@ -7844,7 +7880,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -7862,7 +7898,8 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -7885,13 +7922,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7901,10 +7939,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "functional-red-black-tree": {
@@ -7919,14 +7957,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -7935,7 +7973,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -7944,9 +7982,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -7957,7 +7995,7 @@
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
       "requires": {
-        "globule": "1.2.0"
+        "globule": "^1.0.0"
       }
     },
     "generate-function": {
@@ -7972,7 +8010,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -7999,7 +8037,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "git-repo-info": {
@@ -8014,7 +8052,7 @@
       "integrity": "sha512-weKz3+5ui1zvbguI/KngiiGJhNwMYzXQa3vjTuMxTNPqvz5tHhpSIxbqfJQBQG52WHe4hqavEZLVs2SS/BbQRw==",
       "dev": true,
       "requires": {
-        "git-repo-info": "1.4.1"
+        "git-repo-info": "^1.4.1"
       }
     },
     "git-tools": {
@@ -8023,7 +8061,7 @@
       "integrity": "sha1-XkPllEO4pd7bOdumY9pJ55+UOXg=",
       "dev": true,
       "requires": {
-        "spawnback": "1.0.0"
+        "spawnback": "~1.0.0"
       }
     },
     "glob": {
@@ -8031,12 +8069,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -8045,8 +8083,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -8055,7 +8093,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "global": {
@@ -8064,8 +8102,8 @@
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "dev": true,
       "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
       }
     },
     "global-modules": {
@@ -8074,8 +8112,8 @@
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
       "dev": true,
       "requires": {
-        "global-prefix": "0.1.5",
-        "is-windows": "0.2.0"
+        "global-prefix": "^0.1.4",
+        "is-windows": "^0.2.0"
       }
     },
     "global-prefix": {
@@ -8084,10 +8122,10 @@
       "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.5",
-        "is-windows": "0.2.0",
-        "which": "1.3.0"
+        "homedir-polyfill": "^1.0.0",
+        "ini": "^1.3.4",
+        "is-windows": "^0.2.0",
+        "which": "^1.2.12"
       }
     },
     "globals": {
@@ -8101,12 +8139,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -8123,9 +8161,9 @@
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4"
+        "glob": "~7.1.1",
+        "lodash": "~4.17.4",
+        "minimatch": "~3.0.2"
       }
     },
     "graceful-fs": {
@@ -8152,10 +8190,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -8170,7 +8208,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -8187,8 +8225,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "harmony-reflect": {
@@ -8202,7 +8240,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-binary": {
@@ -8245,10 +8283,10 @@
       "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
       "integrity": "sha512-NE//rDaCFpWHViw30YM78OAGBShU+g4dnUGY3UWGyEzPOGYg/ptOjk32nEc+bC1xz+RfK5UIs6lOL6eQdrV4Ow==",
       "requires": {
-        "broccoli-kitchen-sink-helpers": "0.3.1",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "resolve": "1.5.0"
+        "broccoli-kitchen-sink-helpers": "^0.3.1",
+        "heimdalljs": "^0.2.3",
+        "heimdalljs-logger": "^0.1.7",
+        "resolve": "^1.4.0"
       }
     },
     "hasha": {
@@ -8257,8 +8295,8 @@
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "dev": true,
       "requires": {
-        "is-stream": "1.1.0",
-        "pinkie-promise": "2.0.1"
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "hawk": {
@@ -8267,10 +8305,10 @@
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "heimdalljs": {
@@ -8278,7 +8316,7 @@
       "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
       "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
       "requires": {
-        "rsvp": "3.2.1"
+        "rsvp": "~3.2.1"
       },
       "dependencies": {
         "rsvp": {
@@ -8294,8 +8332,8 @@
       "integrity": "sha1-1ASmVojGcUxIVGntNJXaSFNEAnI=",
       "dev": true,
       "requires": {
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9"
+        "heimdalljs": "^0.2.0",
+        "heimdalljs-logger": "^0.1.7"
       }
     },
     "heimdalljs-graph": {
@@ -8309,8 +8347,8 @@
       "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
       "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY=",
       "requires": {
-        "debug": "2.6.9",
-        "heimdalljs": "0.2.5"
+        "debug": "^2.2.0",
+        "heimdalljs": "^0.2.0"
       }
     },
     "hoek": {
@@ -8324,8 +8362,8 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "homedir-polyfill": {
@@ -8334,7 +8372,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
@@ -8349,11 +8387,11 @@
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.3.0",
-        "domutils": "1.5.1",
-        "entities": "1.0.0",
-        "readable-stream": "1.1.14"
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
       },
       "dependencies": {
         "domutils": {
@@ -8362,8 +8400,8 @@
           "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
           "dev": true,
           "requires": {
-            "dom-serializer": "0.1.0",
-            "domelementtype": "1.3.0"
+            "dom-serializer": "0",
+            "domelementtype": "1"
           }
         },
         "entities": {
@@ -8384,10 +8422,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         }
       }
@@ -8401,7 +8439,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+        "statuses": ">= 1.3.1 < 2"
       },
       "dependencies": {
         "setprototypeof": {
@@ -8424,8 +8462,8 @@
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
       }
     },
     "http-signature": {
@@ -8434,9 +8472,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -8481,7 +8519,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "indexof": {
@@ -8501,8 +8539,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -8522,11 +8560,11 @@
       "integrity": "sha1-UKikTCp5DfrEQbXJTszVRiY1+vY=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "get-stdin": "4.0.1",
-        "minimist": "1.2.0",
-        "sum-up": "1.0.3",
-        "xtend": "4.0.1"
+        "chalk": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "minimist": "^1.1.1",
+        "sum-up": "^1.0.1",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -8543,20 +8581,20 @@
       "integrity": "sha1-4TUWh7kNFQykA86qPO+x4wZb70s=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.2.0",
-        "external-editor": "1.1.1",
-        "figures": "2.0.0",
-        "lodash": "4.17.4",
+        "ansi-escapes": "^1.1.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "external-editor": "^1.1.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.6",
-        "pinkie-promise": "2.0.1",
-        "run-async": "2.3.0",
-        "rx": "4.1.0",
-        "string-width": "2.1.1",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "pinkie-promise": "^2.0.0",
+        "run-async": "^2.2.0",
+        "rx": "^4.1.0",
+        "string-width": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       }
     },
     "invariant": {
@@ -8564,7 +8602,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -8597,7 +8635,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -8612,7 +8650,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-dotfile": {
@@ -8627,7 +8665,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -8647,7 +8685,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -8674,7 +8712,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-integer": {
@@ -8683,7 +8721,7 @@
       "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "is-my-json-valid": {
@@ -8692,10 +8730,10 @@
       "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-number": {
@@ -8704,7 +8742,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-obj": {
@@ -8725,7 +8763,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -8734,7 +8772,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-posix-bracket": {
@@ -8779,7 +8817,7 @@
       "integrity": "sha1-9lHYXDZdRJVdFKUdjXBh8/a0d5w=",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2"
+        "core-util-is": "~1.0.0"
       }
     },
     "is-typedarray": {
@@ -8839,20 +8877,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.10.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.0",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "abbrev": {
@@ -8873,11 +8911,11 @@
           "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
           "dev": true,
           "requires": {
-            "esprima": "2.7.3",
-            "estraverse": "1.9.3",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.2.0"
+            "esprima": "^2.7.1",
+            "estraverse": "^1.9.1",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.2.0"
           }
         },
         "esprima": {
@@ -8898,11 +8936,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -8924,7 +8962,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "supports-color": {
@@ -8933,7 +8971,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "wordwrap": {
@@ -8949,9 +8987,9 @@
       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
       "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
       "requires": {
-        "binaryextensions": "2.0.0",
-        "editions": "1.3.3",
-        "textextensions": "2.1.0"
+        "binaryextensions": "1 || 2",
+        "editions": "^1.1.1",
+        "textextensions": "1 || 2"
       }
     },
     "jimp": {
@@ -8960,22 +8998,22 @@
       "integrity": "sha1-3VKak3GQ9ClXp5N9Gsw6d2KZbqI=",
       "dev": true,
       "requires": {
-        "bignumber.js": "2.4.0",
+        "bignumber.js": "^2.1.0",
         "bmp-js": "0.0.3",
-        "es6-promise": "3.3.1",
-        "exif-parser": "0.1.12",
-        "file-type": "3.9.0",
-        "jpeg-js": "0.2.0",
-        "load-bmfont": "1.3.0",
-        "mime": "1.6.0",
+        "es6-promise": "^3.0.2",
+        "exif-parser": "^0.1.9",
+        "file-type": "^3.1.0",
+        "jpeg-js": "^0.2.0",
+        "load-bmfont": "^1.2.3",
+        "mime": "^1.3.4",
         "mkdirp": "0.5.1",
-        "pixelmatch": "4.0.2",
-        "pngjs": "3.3.1",
-        "read-chunk": "1.0.1",
-        "request": "2.83.0",
-        "stream-to-buffer": "0.1.0",
-        "tinycolor2": "1.4.1",
-        "url-regex": "3.2.0"
+        "pixelmatch": "^4.0.0",
+        "pngjs": "^3.0.0",
+        "read-chunk": "^1.0.1",
+        "request": "^2.65.0",
+        "stream-to-buffer": "^0.1.0",
+        "tinycolor2": "^1.1.2",
+        "url-regex": "^3.0.0"
       }
     },
     "jpeg-js": {
@@ -9019,8 +9057,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -9052,7 +9090,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -9084,7 +9122,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -9128,7 +9166,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "klaw": {
@@ -9137,7 +9175,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "lazy-cache": {
@@ -9152,7 +9190,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "leek": {
@@ -9161,9 +9199,9 @@
       "integrity": "sha1-5ADlfw5g2O8r1NBo3EKKVDRdvNo=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "lodash.assign": "3.2.0",
-        "rsvp": "3.6.2"
+        "debug": "^2.1.0",
+        "lodash.assign": "^3.2.0",
+        "rsvp": "^3.0.21"
       }
     },
     "leven": {
@@ -9178,8 +9216,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "linkify-it": {
@@ -9188,7 +9226,7 @@
       "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
       "dev": true,
       "requires": {
-        "uc.micro": "1.0.3"
+        "uc.micro": "^1.0.1"
       }
     },
     "livereload-js": {
@@ -9204,12 +9242,12 @@
       "dev": true,
       "requires": {
         "buffer-equal": "0.0.1",
-        "mime": "1.6.0",
-        "parse-bmfont-ascii": "1.0.6",
-        "parse-bmfont-binary": "1.0.6",
-        "parse-bmfont-xml": "1.1.3",
-        "xhr": "2.4.1",
-        "xtend": "4.0.1"
+        "mime": "^1.3.4",
+        "parse-bmfont-ascii": "^1.0.3",
+        "parse-bmfont-binary": "^1.0.5",
+        "parse-bmfont-xml": "^1.1.0",
+        "xhr": "^2.0.1",
+        "xtend": "^4.0.0"
       }
     },
     "load-json-file": {
@@ -9218,11 +9256,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -9237,7 +9275,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -9254,8 +9292,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -9277,8 +9315,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       },
       "dependencies": {
         "lodash.keys": {
@@ -9287,9 +9325,9 @@
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
           "dev": true,
           "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
           }
         }
       }
@@ -9300,9 +9338,9 @@
       "integrity": "sha1-K1vEUqDhBhQ7IYafIzvbWHQX0kg=",
       "dev": true,
       "requires": {
-        "lodash._basecreate": "2.3.0",
-        "lodash._setbinddata": "2.3.0",
-        "lodash.isobject": "2.3.0"
+        "lodash._basecreate": "~2.3.0",
+        "lodash._setbinddata": "~2.3.0",
+        "lodash.isobject": "~2.3.0"
       }
     },
     "lodash._basecopy": {
@@ -9317,9 +9355,9 @@
       "integrity": "sha1-m4ioak3P97fzxh2Dovz8BnHsneA=",
       "dev": true,
       "requires": {
-        "lodash._renative": "2.3.0",
-        "lodash.isobject": "2.3.0",
-        "lodash.noop": "2.3.0"
+        "lodash._renative": "~2.3.0",
+        "lodash.isobject": "~2.3.0",
+        "lodash.noop": "~2.3.0"
       }
     },
     "lodash._basecreatecallback": {
@@ -9328,10 +9366,10 @@
       "integrity": "sha1-N7KrF1kaM56YjbMln81GAZ16w2I=",
       "dev": true,
       "requires": {
-        "lodash._setbinddata": "2.3.0",
-        "lodash.bind": "2.3.0",
-        "lodash.identity": "2.3.0",
-        "lodash.support": "2.3.0"
+        "lodash._setbinddata": "~2.3.0",
+        "lodash.bind": "~2.3.0",
+        "lodash.identity": "~2.3.0",
+        "lodash.support": "~2.3.0"
       }
     },
     "lodash._basecreatewrapper": {
@@ -9340,10 +9378,10 @@
       "integrity": "sha1-qgxhrZYETDkzN2ExSDqXWcNlEkc=",
       "dev": true,
       "requires": {
-        "lodash._basecreate": "2.3.0",
-        "lodash._setbinddata": "2.3.0",
-        "lodash._slice": "2.3.0",
-        "lodash.isobject": "2.3.0"
+        "lodash._basecreate": "~2.3.0",
+        "lodash._setbinddata": "~2.3.0",
+        "lodash._slice": "~2.3.0",
+        "lodash.isobject": "~2.3.0"
       }
     },
     "lodash._baseflatten": {
@@ -9352,8 +9390,8 @@
       "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
       "dev": true,
       "requires": {
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash._bindcallback": {
@@ -9368,9 +9406,9 @@
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
       "dev": true,
       "requires": {
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash.restparam": "3.6.1"
+        "lodash._bindcallback": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
       }
     },
     "lodash._createwrapper": {
@@ -9379,9 +9417,9 @@
       "integrity": "sha1-0arhEC2t9EDo4G/BM6bt1/4UYHU=",
       "dev": true,
       "requires": {
-        "lodash._basebind": "2.3.0",
-        "lodash._basecreatewrapper": "2.3.0",
-        "lodash.isfunction": "2.3.0"
+        "lodash._basebind": "~2.3.0",
+        "lodash._basecreatewrapper": "~2.3.0",
+        "lodash.isfunction": "~2.3.0"
       }
     },
     "lodash._escapehtmlchar": {
@@ -9390,7 +9428,7 @@
       "integrity": "sha1-0D2mvYLu3zjcCltQPXQOzQ6JRZI=",
       "dev": true,
       "requires": {
-        "lodash._htmlescapes": "2.3.0"
+        "lodash._htmlescapes": "~2.3.0"
       }
     },
     "lodash._escapestringchar": {
@@ -9441,8 +9479,8 @@
       "integrity": "sha1-25ILVax/P/glk5rOubosIxcT0k0=",
       "dev": true,
       "requires": {
-        "lodash._htmlescapes": "2.3.0",
-        "lodash.keys": "2.3.0"
+        "lodash._htmlescapes": "~2.3.0",
+        "lodash.keys": "~2.3.0"
       }
     },
     "lodash._setbinddata": {
@@ -9451,8 +9489,8 @@
       "integrity": "sha1-5WEEkKzRMnfVmFjZW18nJ/FQjwQ=",
       "dev": true,
       "requires": {
-        "lodash._renative": "2.3.0",
-        "lodash.noop": "2.3.0"
+        "lodash._renative": "~2.3.0",
+        "lodash.noop": "~2.3.0"
       }
     },
     "lodash._shimkeys": {
@@ -9461,7 +9499,7 @@
       "integrity": "sha1-YR+TFJ4+bHIQlrSHae8pU3rai6k=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "2.3.0"
+        "lodash._objecttypes": "~2.3.0"
       }
     },
     "lodash._slice": {
@@ -9476,9 +9514,9 @@
       "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._createassigner": "3.1.1",
-        "lodash.keys": "3.1.2"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._createassigner": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       },
       "dependencies": {
         "lodash.keys": {
@@ -9487,9 +9525,9 @@
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
           "dev": true,
           "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
           }
         }
       }
@@ -9506,9 +9544,9 @@
       "integrity": "sha1-wqjhi2jl7MFS4rFoJmEW/qWwFsw=",
       "dev": true,
       "requires": {
-        "lodash._createwrapper": "2.3.0",
-        "lodash._renative": "2.3.0",
-        "lodash._slice": "2.3.0"
+        "lodash._createwrapper": "~2.3.0",
+        "lodash._renative": "~2.3.0",
+        "lodash._slice": "~2.3.0"
       }
     },
     "lodash.clonedeep": {
@@ -9523,7 +9561,7 @@
       "integrity": "sha1-gSIRw3ipTMKdWqTjNGzwv846ffU=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1"
+        "lodash._getnative": "^3.0.0"
       }
     },
     "lodash.defaults": {
@@ -9532,8 +9570,8 @@
       "integrity": "sha1-qDKwAfE487uXIcKBmip8xa4h7SU=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "2.3.0",
-        "lodash.keys": "2.3.0"
+        "lodash._objecttypes": "~2.3.0",
+        "lodash.keys": "~2.3.0"
       }
     },
     "lodash.defaultsdeep": {
@@ -9548,9 +9586,9 @@
       "integrity": "sha1-hEw4xY+EThNi6+lnJhWbYs9fKlg=",
       "dev": true,
       "requires": {
-        "lodash._escapehtmlchar": "2.3.0",
-        "lodash._reunescapedhtml": "2.3.0",
-        "lodash.keys": "2.3.0"
+        "lodash._escapehtmlchar": "~2.3.0",
+        "lodash._reunescapedhtml": "~2.3.0",
+        "lodash.keys": "~2.3.0"
       }
     },
     "lodash.find": {
@@ -9565,8 +9603,8 @@
       "integrity": "sha1-3hz1d1j49EeTGdNcPpzGDEUBk4w=",
       "dev": true,
       "requires": {
-        "lodash._baseflatten": "3.1.4",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseflatten": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.foreach": {
@@ -9575,8 +9613,8 @@
       "integrity": "sha1-CDQEyR6EbudyRf3512UZxosq8Wg=",
       "dev": true,
       "requires": {
-        "lodash._basecreatecallback": "2.3.0",
-        "lodash.forown": "2.3.0"
+        "lodash._basecreatecallback": "~2.3.0",
+        "lodash.forown": "~2.3.0"
       }
     },
     "lodash.forown": {
@@ -9585,9 +9623,9 @@
       "integrity": "sha1-JPtKr4ANRfwtxgv+w84EyDajrX8=",
       "dev": true,
       "requires": {
-        "lodash._basecreatecallback": "2.3.0",
-        "lodash._objecttypes": "2.3.0",
-        "lodash.keys": "2.3.0"
+        "lodash._basecreatecallback": "~2.3.0",
+        "lodash._objecttypes": "~2.3.0",
+        "lodash.keys": "~2.3.0"
       }
     },
     "lodash.identity": {
@@ -9620,7 +9658,7 @@
       "integrity": "sha1-LhbT/Fg9qYMZaJU/LY5tc0NPZ5k=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "2.3.0"
+        "lodash._objecttypes": "~2.3.0"
       }
     },
     "lodash.keys": {
@@ -9629,9 +9667,9 @@
       "integrity": "sha1-s1D0+Syqn0WkouzwGEVM8vKK4lM=",
       "dev": true,
       "requires": {
-        "lodash._renative": "2.3.0",
-        "lodash._shimkeys": "2.3.0",
-        "lodash.isobject": "2.3.0"
+        "lodash._renative": "~2.3.0",
+        "lodash._shimkeys": "~2.3.0",
+        "lodash.isobject": "~2.3.0"
       }
     },
     "lodash.merge": {
@@ -9670,7 +9708,7 @@
       "integrity": "sha1-fq8DivTw1qq3drRKptz8gDNMm/0=",
       "dev": true,
       "requires": {
-        "lodash._renative": "2.3.0"
+        "lodash._renative": "~2.3.0"
       }
     },
     "lodash.template": {
@@ -9679,8 +9717,8 @@
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.templatesettings": "4.1.0"
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
       },
       "dependencies": {
         "lodash._reinterpolate": {
@@ -9695,7 +9733,7 @@
           "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "3.0.0"
+            "lodash._reinterpolate": "~3.0.0"
           }
         }
       }
@@ -9706,8 +9744,8 @@
       "integrity": "sha1-MD0TLDQnEAQNWhjvqi1XL9A/jNw=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "2.3.0",
-        "lodash.escape": "2.3.0"
+        "lodash._reinterpolate": "~2.3.0",
+        "lodash.escape": "~2.3.0"
       }
     },
     "lodash.uniq": {
@@ -9728,7 +9766,7 @@
       "integrity": "sha1-ypb75gogsLDsK6K6X8anZb0Uo7o=",
       "dev": true,
       "requires": {
-        "lodash.keys": "2.3.0"
+        "lodash.keys": "~2.3.0"
       }
     },
     "log-symbols": {
@@ -9737,7 +9775,7 @@
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.0.0"
       }
     },
     "longest": {
@@ -9751,7 +9789,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "loud-rejection": {
@@ -9760,8 +9798,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lower-case": {
@@ -9776,8 +9814,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "make-array": {
@@ -9792,7 +9830,7 @@
       "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "makeerror": {
@@ -9801,7 +9839,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.4"
+        "tmpl": "1.0.x"
       }
     },
     "map-obj": {
@@ -9816,11 +9854,11 @@
       "integrity": "sha512-tNuOCCfunY5v5uhcO2AUMArvKAyKMygX8tfup/JrgnsDqcCATQsAExBq7o5Ml9iMmO82bk6jYNLj6khcrl0JGA==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "entities": "1.1.1",
-        "linkify-it": "2.0.3",
-        "mdurl": "1.0.1",
-        "uc.micro": "1.0.3"
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.3"
       }
     },
     "markdown-it-terminal": {
@@ -9829,11 +9867,11 @@
       "integrity": "sha1-VFq9jdAcPWI1O/zqcdtYC1HSK9k=",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.0",
-        "cardinal": "1.0.0",
-        "cli-table": "0.3.1",
-        "lodash.merge": "4.6.0",
-        "markdown-it": "8.4.0"
+        "ansi-styles": "^3.0.0",
+        "cardinal": "^1.0.0",
+        "cli-table": "^0.3.1",
+        "lodash.merge": "^4.6.0",
+        "markdown-it": "^8.3.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9842,7 +9880,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         }
       }
@@ -9852,7 +9890,7 @@
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
       "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.2"
       }
     },
     "md5-hex": {
@@ -9861,7 +9899,7 @@
       "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
       "dev": true,
       "requires": {
-        "md5-o-matic": "0.1.1"
+        "md5-o-matic": "^0.1.1"
       }
     },
     "md5-o-matic": {
@@ -9888,7 +9926,7 @@
       "integrity": "sha1-Jz/3d6tg/sWZsRY1UlUoLMosUMI=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.0.34"
+        "readable-stream": "~1.0.2"
       }
     },
     "meow": {
@@ -9897,16 +9935,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -9929,7 +9967,7 @@
       "integrity": "sha1-3UIkjrlrtqUVIXJDIccv+Vg93oA=",
       "dev": true,
       "requires": {
-        "lodash": "2.4.2"
+        "lodash": "~2.4.1"
       },
       "dependencies": {
         "lodash": {
@@ -9951,12 +9989,12 @@
       "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
       "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
       "requires": {
-        "can-symlink": "1.0.0",
-        "fs-tree-diff": "0.5.7",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "rimraf": "2.6.2",
-        "symlink-or-copy": "1.1.8"
+        "can-symlink": "^1.0.0",
+        "fs-tree-diff": "^0.5.4",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0"
       }
     },
     "methods": {
@@ -9971,19 +10009,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "mime": {
@@ -10004,7 +10042,7 @@
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       }
     },
     "mimic-fn": {
@@ -10019,7 +10057,7 @@
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "dev": true,
       "requires": {
-        "dom-walk": "0.1.1"
+        "dom-walk": "^0.1.0"
       }
     },
     "minimatch": {
@@ -10027,7 +10065,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -10060,7 +10098,7 @@
       "integrity": "sha1-PvR4VrAtU7cYoQpewgI6opnge/U=",
       "dev": true,
       "requires": {
-        "moment": "2.20.1"
+        "moment": ">= 2.6.0"
       }
     },
     "morgan": {
@@ -10069,11 +10107,11 @@
       "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
       "dev": true,
       "requires": {
-        "basic-auth": "2.0.0",
+        "basic-auth": "~2.0.0",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "on-finished": "2.3.0",
-        "on-headers": "1.0.1"
+        "depd": "~1.1.1",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
       }
     },
     "mout": {
@@ -10105,9 +10143,9 @@
       "integrity": "sha1-ERRfTZEERupmHYq3/O9T9q0WSuU=",
       "dev": true,
       "requires": {
-        "jquery-deferred": "0.3.1",
-        "lodash.defaultsdeep": "4.6.0",
-        "qs": "6.5.1"
+        "jquery-deferred": "^0.3.0",
+        "lodash.defaultsdeep": "^4.6.0",
+        "qs": "^6.2.0"
       }
     },
     "nan": {
@@ -10134,7 +10172,7 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.1"
       }
     },
     "node-dir": {
@@ -10143,7 +10181,7 @@
       "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
       "dev": true,
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.2"
       }
     },
     "node-fetch": {
@@ -10152,8 +10190,8 @@
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "dev": true,
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-gyp": {
@@ -10162,19 +10200,19 @@
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "osenv": "0.1.4",
-        "request": "2.83.0",
-        "rimraf": "2.6.2",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "1.3.0"
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "2",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
       },
       "dependencies": {
         "semver": {
@@ -10203,10 +10241,10 @@
       "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
       "dev": true,
       "requires": {
-        "growly": "1.3.0",
-        "semver": "5.4.1",
-        "shellwords": "0.1.1",
-        "which": "1.3.0"
+        "growly": "^1.3.0",
+        "semver": "^5.3.0",
+        "shellwords": "^0.1.0",
+        "which": "^1.2.12"
       }
     },
     "node-rest-client": {
@@ -10215,8 +10253,8 @@
       "integrity": "sha1-jTxWa4F+JzlMtyc3g6Qcrv4+WVU=",
       "dev": true,
       "requires": {
-        "debug": "2.2.0",
-        "xml2js": "0.4.19"
+        "debug": "~2.2.0",
+        "xml2js": ">=0.2.4"
       },
       "dependencies": {
         "debug": {
@@ -10242,25 +10280,25 @@
       "integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
       "dev": true,
       "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
-        "get-stdin": "4.0.1",
-        "glob": "7.1.2",
-        "in-publish": "2.0.0",
-        "lodash.assign": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.mergewith": "4.6.0",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "2.8.0",
-        "node-gyp": "3.6.2",
-        "npmlog": "4.1.2",
-        "request": "2.79.0",
-        "sass-graph": "2.2.4",
-        "stdout-stream": "1.4.0",
-        "true-case-path": "1.0.2"
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.clonedeep": "^4.3.2",
+        "lodash.mergewith": "^4.6.0",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.3.2",
+        "node-gyp": "^3.3.1",
+        "npmlog": "^4.0.0",
+        "request": "~2.79.0",
+        "sass-graph": "^2.2.4",
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
       },
       "dependencies": {
         "assert-plus": {
@@ -10281,7 +10319,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "caseless": {
@@ -10296,8 +10334,8 @@
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.1",
-            "which": "1.3.0"
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
           }
         },
         "cryptiles": {
@@ -10306,7 +10344,7 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "form-data": {
@@ -10315,9 +10353,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "har-validator": {
@@ -10326,10 +10364,10 @@
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.12.2",
-            "is-my-json-valid": "2.17.1",
-            "pinkie-promise": "2.0.1"
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "hawk": {
@@ -10338,10 +10376,10 @@
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -10356,9 +10394,9 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "lodash.assign": {
@@ -10379,26 +10417,26 @@
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.1.0"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.3.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1",
+            "uuid": "^3.0.0"
           }
         },
         "sntp": {
@@ -10407,7 +10445,7 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "tunnel-agent": {
@@ -10424,7 +10462,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -10433,10 +10471,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -10445,7 +10483,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm": {
@@ -10454,91 +10492,91 @@
       "integrity": "sha1-2y9x09qg56mQd+3UwhORmDTpXrI=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.7",
-        "ansi-regex": "2.0.0",
-        "ansicolors": "0.3.2",
-        "ansistyles": "0.1.3",
-        "aproba": "1.0.1",
-        "archy": "1.0.0",
-        "async-some": "1.0.2",
-        "chownr": "1.0.1",
-        "cmd-shim": "2.0.1",
-        "columnify": "1.5.4",
-        "config-chain": "1.1.9",
-        "debuglog": "1.0.1",
-        "dezalgo": "1.0.3",
-        "editor": "1.0.0",
-        "fs-vacuum": "1.2.7",
-        "fs-write-stream-atomic": "1.0.8",
-        "fstream": "1.0.8",
-        "fstream-npm": "1.0.7",
-        "glob": "6.0.3",
-        "graceful-fs": "4.1.2",
-        "has-unicode": "2.0.0",
-        "hosted-git-info": "2.1.4",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "inflight": "1.0.4",
-        "inherits": "2.0.1",
-        "ini": "1.3.4",
-        "init-package-json": "1.9.1",
-        "lockfile": "1.0.1",
-        "lodash._baseindexof": "3.1.0",
-        "lodash._baseuniq": "3.0.3",
-        "lodash._bindcallback": "3.0.1",
-        "lodash._cacheindexof": "3.0.2",
-        "lodash._createcache": "3.1.2",
-        "lodash._getnative": "3.9.1",
-        "lodash.clonedeep": "3.0.2",
-        "lodash.isarguments": "3.0.4",
-        "lodash.isarray": "3.0.4",
-        "lodash.keys": "3.1.2",
-        "lodash.restparam": "3.6.1",
-        "lodash.union": "3.1.0",
-        "lodash.uniq": "3.2.2",
-        "lodash.without": "3.2.1",
-        "mkdirp": "0.5.1",
-        "node-gyp": "3.2.1",
-        "nopt": "3.0.6",
-        "normalize-git-url": "3.0.1",
-        "normalize-package-data": "2.3.5",
-        "npm-cache-filename": "1.0.2",
-        "npm-install-checks": "2.0.1",
-        "npm-package-arg": "4.1.0",
-        "npm-registry-client": "7.0.9",
-        "npm-user-validate": "0.1.2",
-        "npmlog": "2.0.0",
-        "once": "1.3.3",
-        "opener": "1.4.1",
-        "osenv": "0.1.3",
-        "path-is-inside": "1.0.1",
-        "read": "1.0.7",
-        "read-cmd-shim": "1.0.1",
-        "read-installed": "4.0.3",
-        "read-package-json": "2.0.2",
-        "read-package-tree": "5.1.2",
-        "readable-stream": "2.0.5",
-        "readdir-scoped-modules": "1.0.2",
-        "realize-package-specifier": "3.0.1",
-        "request": "2.67.0",
-        "retry": "0.8.0",
-        "rimraf": "2.5.0",
-        "semver": "5.1.0",
-        "sha": "2.0.1",
-        "slide": "1.1.6",
-        "sorted-object": "1.0.0",
-        "strip-ansi": "3.0.0",
-        "tar": "2.2.1",
-        "text-table": "0.2.0",
+        "abbrev": "~1.0.7",
+        "ansi-regex": "*",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "~1.0.1",
+        "archy": "~1.0.0",
+        "async-some": "~1.0.2",
+        "chownr": "~1.0.1",
+        "cmd-shim": "~2.0.1",
+        "columnify": "~1.5.4",
+        "config-chain": "~1.1.9",
+        "debuglog": "*",
+        "dezalgo": "~1.0.3",
+        "editor": "~1.0.0",
+        "fs-vacuum": "~1.2.7",
+        "fs-write-stream-atomic": "~1.0.8",
+        "fstream": "~1.0.8",
+        "fstream-npm": "~1.0.7",
+        "glob": "~6.0.3",
+        "graceful-fs": "~4.1.2",
+        "has-unicode": "~2.0.0",
+        "hosted-git-info": "~2.1.4",
+        "iferr": "~0.1.5",
+        "imurmurhash": "*",
+        "inflight": "~1.0.4",
+        "inherits": "~2.0.1",
+        "ini": "~1.3.4",
+        "init-package-json": "~1.9.1",
+        "lockfile": "~1.0.1",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "*",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~3.0.2",
+        "lodash.isarguments": "*",
+        "lodash.isarray": "*",
+        "lodash.keys": "*",
+        "lodash.restparam": "*",
+        "lodash.union": "~3.1.0",
+        "lodash.uniq": "~3.2.2",
+        "lodash.without": "~3.2.1",
+        "mkdirp": "~0.5.1",
+        "node-gyp": "~3.2.1",
+        "nopt": "~3.0.6",
+        "normalize-git-url": "~3.0.1",
+        "normalize-package-data": "~2.3.5",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "~2.0.1",
+        "npm-package-arg": "~4.1.0",
+        "npm-registry-client": "~7.0.9",
+        "npm-user-validate": "~0.1.2",
+        "npmlog": "~2.0.0",
+        "once": "~1.3.3",
+        "opener": "~1.4.1",
+        "osenv": "~0.1.3",
+        "path-is-inside": "~1.0.1",
+        "read": "~1.0.7",
+        "read-cmd-shim": "~1.0.1",
+        "read-installed": "~4.0.3",
+        "read-package-json": "~2.0.2",
+        "read-package-tree": "~5.1.2",
+        "readable-stream": "~2.0.5",
+        "readdir-scoped-modules": "*",
+        "realize-package-specifier": "~3.0.1",
+        "request": "~2.67.0",
+        "retry": "~0.8.0",
+        "rimraf": "~2.5.0",
+        "semver": "~5.1.0",
+        "sha": "~2.0.1",
+        "slide": "~1.1.6",
+        "sorted-object": "~1.0.0",
+        "strip-ansi": "*",
+        "tar": "~2.2.1",
+        "text-table": "~0.2.0",
         "uid-number": "0.0.6",
-        "umask": "1.1.0",
-        "unique-filename": "1.1.0",
-        "unpipe": "1.0.0",
-        "validate-npm-package-license": "3.0.1",
-        "validate-npm-package-name": "2.2.2",
-        "which": "1.2.1",
-        "wrappy": "1.0.1",
-        "write-file-atomic": "1.1.4"
+        "umask": "~1.1.0",
+        "unique-filename": "~1.1.0",
+        "unpipe": "~1.0.0",
+        "validate-npm-package-license": "*",
+        "validate-npm-package-name": "~2.2.2",
+        "which": "~1.2.1",
+        "wrappy": "~1.0.1",
+        "write-file-atomic": "~1.1.4"
       },
       "dependencies": {
         "abbrev": {
@@ -10576,7 +10614,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "dezalgo": "1.0.3"
+            "dezalgo": "^1.0.2"
           }
         },
         "chownr": {
@@ -10589,8 +10627,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "3.0.8",
-            "mkdirp": "0.5.1"
+            "graceful-fs": ">3.0.1 <4.0.0-0",
+            "mkdirp": "~0.5.0"
           },
           "dependencies": {
             "graceful-fs": {
@@ -10605,8 +10643,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-ansi": "3.0.0",
-            "wcwidth": "1.0.0"
+            "strip-ansi": "^3.0.0",
+            "wcwidth": "^1.0.0"
           },
           "dependencies": {
             "wcwidth": {
@@ -10614,7 +10652,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "defaults": "1.0.3"
+                "defaults": "^1.0.0"
               },
               "dependencies": {
                 "defaults": {
@@ -10622,7 +10660,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "clone": "1.0.2"
+                    "clone": "^1.0.2"
                   },
                   "dependencies": {
                     "clone": {
@@ -10641,8 +10679,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ini": "1.3.4",
-            "proto-list": "1.2.4"
+            "ini": "1",
+            "proto-list": "~1.2.1"
           },
           "dependencies": {
             "proto-list": {
@@ -10662,8 +10700,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "asap": "2.0.3",
-            "wrappy": "1.0.1"
+            "asap": "^2.0.0",
+            "wrappy": "1"
           },
           "dependencies": {
             "asap": {
@@ -10683,9 +10721,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.2",
-            "path-is-inside": "1.0.1",
-            "rimraf": "2.5.0"
+            "graceful-fs": "^4.1.2",
+            "path-is-inside": "^1.0.1",
+            "rimraf": "^2.2.8"
           }
         },
         "fs-write-stream-atomic": {
@@ -10693,10 +10731,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.2",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.0.5"
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
           }
         },
         "fstream": {
@@ -10704,10 +10742,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.2",
-            "inherits": "2.0.1",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.5.0"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "fstream-npm": {
@@ -10715,8 +10753,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fstream-ignore": "1.0.3",
-            "inherits": "2.0.1"
+            "fstream-ignore": "^1.0.0",
+            "inherits": "2"
           },
           "dependencies": {
             "fstream-ignore": {
@@ -10724,9 +10762,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "fstream": "1.0.8",
-                "inherits": "2.0.1",
-                "minimatch": "3.0.0"
+                "fstream": "^1.0.0",
+                "inherits": "2",
+                "minimatch": "^3.0.0"
               },
               "dependencies": {
                 "minimatch": {
@@ -10734,7 +10772,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.1"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -10742,7 +10780,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.2.1",
+                        "balanced-match": "^0.2.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -10769,11 +10807,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inflight": "1.0.4",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.0",
-            "once": "1.3.3",
-            "path-is-absolute": "1.0.0"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           },
           "dependencies": {
             "minimatch": {
@@ -10781,7 +10819,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.2"
+                "brace-expansion": "^1.0.0"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -10789,7 +10827,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "balanced-match": "0.3.0",
+                    "balanced-match": "^0.3.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -10844,8 +10882,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.3.3",
-            "wrappy": "1.0.1"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -10863,14 +10901,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "5.0.15",
-            "npm-package-arg": "4.1.0",
-            "promzard": "0.3.0",
-            "read": "1.0.7",
-            "read-package-json": "2.0.2",
-            "semver": "5.1.0",
-            "validate-npm-package-license": "3.0.1",
-            "validate-npm-package-name": "2.2.2"
+            "glob": "^5.0.3",
+            "npm-package-arg": "^4.0.0",
+            "promzard": "^0.3.0",
+            "read": "~1.0.1",
+            "read-package-json": "1 || 2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "validate-npm-package-license": "^3.0.1",
+            "validate-npm-package-name": "^2.0.1"
           },
           "dependencies": {
             "glob": {
@@ -10879,11 +10917,11 @@
               "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
               "dev": true,
               "requires": {
-                "inflight": "1.0.4",
-                "inherits": "2.0.1",
-                "minimatch": "3.0.4",
-                "once": "1.3.3",
-                "path-is-absolute": "1.0.1"
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "promzard": {
@@ -10891,7 +10929,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "read": "1.0.7"
+                "read": "1"
               }
             }
           }
@@ -10911,9 +10949,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._baseindexof": "3.1.0",
-            "lodash._cacheindexof": "3.0.2",
-            "lodash._createcache": "3.1.2"
+            "lodash._baseindexof": "^3.0.0",
+            "lodash._cacheindexof": "^3.0.0",
+            "lodash._createcache": "^3.0.0"
           }
         },
         "lodash._bindcallback": {
@@ -10931,7 +10969,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._getnative": "3.9.1"
+            "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
@@ -10944,8 +10982,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._baseclone": "3.3.0",
-            "lodash._bindcallback": "3.0.1"
+            "lodash._baseclone": "^3.0.0",
+            "lodash._bindcallback": "^3.0.0"
           },
           "dependencies": {
             "lodash._baseclone": {
@@ -10953,12 +10991,12 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lodash._arraycopy": "3.0.0",
-                "lodash._arrayeach": "3.0.0",
-                "lodash._baseassign": "3.2.0",
-                "lodash._basefor": "3.0.2",
-                "lodash.isarray": "3.0.4",
-                "lodash.keys": "3.1.2"
+                "lodash._arraycopy": "^3.0.0",
+                "lodash._arrayeach": "^3.0.0",
+                "lodash._baseassign": "^3.0.0",
+                "lodash._basefor": "^3.0.0",
+                "lodash.isarray": "^3.0.0",
+                "lodash.keys": "^3.0.0"
               },
               "dependencies": {
                 "lodash._arraycopy": {
@@ -10976,8 +11014,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "lodash._basecopy": "3.0.1",
-                    "lodash.keys": "3.1.2"
+                    "lodash._basecopy": "^3.0.0",
+                    "lodash.keys": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._basecopy": {
@@ -11011,9 +11049,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.0.4",
-            "lodash.isarray": "3.0.4"
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
           }
         },
         "lodash.restparam": {
@@ -11026,9 +11064,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._baseflatten": "3.1.4",
-            "lodash._baseuniq": "3.0.3",
-            "lodash.restparam": "3.6.1"
+            "lodash._baseflatten": "^3.0.0",
+            "lodash._baseuniq": "^3.0.0",
+            "lodash.restparam": "^3.0.0"
           },
           "dependencies": {
             "lodash._baseflatten": {
@@ -11036,8 +11074,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lodash.isarguments": "3.0.4",
-                "lodash.isarray": "3.0.4"
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
               }
             }
           }
@@ -11047,11 +11085,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._basecallback": "3.3.1",
-            "lodash._baseuniq": "3.0.3",
-            "lodash._getnative": "3.9.1",
-            "lodash._isiterateecall": "3.0.9",
-            "lodash.isarray": "3.0.4"
+            "lodash._basecallback": "^3.0.0",
+            "lodash._baseuniq": "^3.0.0",
+            "lodash._getnative": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
           },
           "dependencies": {
             "lodash._basecallback": {
@@ -11059,10 +11097,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lodash._baseisequal": "3.0.7",
-                "lodash._bindcallback": "3.0.1",
-                "lodash.isarray": "3.0.4",
-                "lodash.pairs": "3.0.1"
+                "lodash._baseisequal": "^3.0.0",
+                "lodash._bindcallback": "^3.0.0",
+                "lodash.isarray": "^3.0.0",
+                "lodash.pairs": "^3.0.0"
               },
               "dependencies": {
                 "lodash._baseisequal": {
@@ -11070,9 +11108,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "lodash.isarray": "3.0.4",
-                    "lodash.istypedarray": "3.0.2",
-                    "lodash.keys": "3.1.2"
+                    "lodash.isarray": "^3.0.0",
+                    "lodash.istypedarray": "^3.0.0",
+                    "lodash.keys": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash.istypedarray": {
@@ -11087,7 +11125,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "lodash.keys": "3.1.2"
+                    "lodash.keys": "^3.0.0"
                   }
                 }
               }
@@ -11104,8 +11142,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._basedifference": "3.0.3",
-            "lodash.restparam": "3.6.1"
+            "lodash._basedifference": "^3.0.0",
+            "lodash.restparam": "^3.0.0"
           },
           "dependencies": {
             "lodash._basedifference": {
@@ -11113,9 +11151,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lodash._baseindexof": "3.1.0",
-                "lodash._cacheindexof": "3.0.2",
-                "lodash._createcache": "3.1.2"
+                "lodash._baseindexof": "^3.0.0",
+                "lodash._cacheindexof": "^3.0.0",
+                "lodash._createcache": "^3.0.0"
               }
             }
           }
@@ -11140,20 +11178,20 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fstream": "1.0.8",
-            "glob": "4.5.3",
-            "graceful-fs": "4.1.2",
-            "minimatch": "1.0.0",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "1.2.1",
-            "osenv": "0.1.3",
-            "path-array": "1.0.0",
-            "request": "2.67.0",
-            "rimraf": "2.5.0",
-            "semver": "5.1.0",
-            "tar": "2.2.1",
-            "which": "1.2.1"
+            "fstream": "^1.0.0",
+            "glob": "3 || 4",
+            "graceful-fs": "^4.1.2",
+            "minimatch": "1",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1",
+            "osenv": "0",
+            "path-array": "^1.0.0",
+            "request": "2",
+            "rimraf": "2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "tar": "^2.0.0",
+            "which": "1"
           },
           "dependencies": {
             "glob": {
@@ -11161,10 +11199,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inflight": "1.0.4",
-                "inherits": "2.0.1",
-                "minimatch": "2.0.10",
-                "once": "1.3.3"
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^2.0.1",
+                "once": "^1.3.0"
               },
               "dependencies": {
                 "minimatch": {
@@ -11172,7 +11210,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.2"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -11180,7 +11218,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.3.0",
+                        "balanced-match": "^0.3.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -11211,8 +11249,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "2.7.3",
-                "sigmund": "1.0.1"
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
               },
               "dependencies": {
                 "lru-cache": {
@@ -11232,9 +11270,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi": "0.3.0",
-                "are-we-there-yet": "1.0.4",
-                "gauge": "1.2.2"
+                "ansi": "~0.3.0",
+                "are-we-there-yet": "~1.0.0",
+                "gauge": "~1.2.0"
               },
               "dependencies": {
                 "ansi": {
@@ -11247,8 +11285,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "delegates": "0.1.0",
-                    "readable-stream": "1.1.13"
+                    "delegates": "^0.1.0",
+                    "readable-stream": "^1.1.13"
                   },
                   "dependencies": {
                     "delegates": {
@@ -11261,10 +11299,10 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.1",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -11291,11 +11329,11 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "ansi": "0.3.0",
-                    "has-unicode": "1.0.1",
-                    "lodash.pad": "3.1.1",
-                    "lodash.padleft": "3.1.1",
-                    "lodash.padright": "3.1.1"
+                    "ansi": "^0.3.0",
+                    "has-unicode": "^1.0.0",
+                    "lodash.pad": "^3.0.0",
+                    "lodash.padleft": "^3.0.0",
+                    "lodash.padright": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash.pad": {
@@ -11303,8 +11341,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "lodash._basetostring": "3.0.1",
-                        "lodash._createpadding": "3.6.1"
+                        "lodash._basetostring": "^3.0.0",
+                        "lodash._createpadding": "^3.0.0"
                       },
                       "dependencies": {
                         "lodash._basetostring": {
@@ -11317,7 +11355,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "lodash.repeat": "3.0.1"
+                            "lodash.repeat": "^3.0.0"
                           },
                           "dependencies": {
                             "lodash.repeat": {
@@ -11325,7 +11363,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "lodash._basetostring": "3.0.1"
+                                "lodash._basetostring": "^3.0.0"
                               }
                             }
                           }
@@ -11337,8 +11375,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "lodash._basetostring": "3.0.1",
-                        "lodash._createpadding": "3.6.1"
+                        "lodash._basetostring": "^3.0.0",
+                        "lodash._createpadding": "^3.0.0"
                       },
                       "dependencies": {
                         "lodash._basetostring": {
@@ -11351,7 +11389,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "lodash.repeat": "3.0.1"
+                            "lodash.repeat": "^3.0.0"
                           },
                           "dependencies": {
                             "lodash.repeat": {
@@ -11359,7 +11397,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "lodash._basetostring": "3.0.1"
+                                "lodash._basetostring": "^3.0.0"
                               }
                             }
                           }
@@ -11371,8 +11409,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "lodash._basetostring": "3.0.1",
-                        "lodash._createpadding": "3.6.1"
+                        "lodash._basetostring": "^3.0.0",
+                        "lodash._createpadding": "^3.0.0"
                       },
                       "dependencies": {
                         "lodash._basetostring": {
@@ -11385,7 +11423,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "lodash.repeat": "3.0.1"
+                            "lodash.repeat": "^3.0.0"
                           },
                           "dependencies": {
                             "lodash.repeat": {
@@ -11393,7 +11431,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "lodash._basetostring": "3.0.1"
+                                "lodash._basetostring": "^3.0.0"
                               }
                             }
                           }
@@ -11409,7 +11447,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "array-index": "0.1.1"
+                "array-index": "~0.1.0"
               },
               "dependencies": {
                 "array-index": {
@@ -11417,7 +11455,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "debug": "2.2.0"
+                    "debug": "*"
                   },
                   "dependencies": {
                     "debug": {
@@ -11446,7 +11484,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "1.0.7"
+            "abbrev": "1"
           }
         },
         "normalize-git-url": {
@@ -11459,10 +11497,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.1.4",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.1.0",
-            "validate-npm-package-license": "3.0.1"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           },
           "dependencies": {
             "is-builtin-module": {
@@ -11470,7 +11508,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "builtin-modules": "1.1.0"
+                "builtin-modules": "^1.0.0"
               },
               "dependencies": {
                 "builtin-modules": {
@@ -11492,8 +11530,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "npmlog": "1.2.1",
-            "semver": "5.1.0"
+            "npmlog": "0.1 || 1",
+            "semver": "^2.3.0 || 3.x || 4 || 5"
           },
           "dependencies": {
             "has-unicode": {
@@ -11507,9 +11545,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi": "0.3.0",
-                "are-we-there-yet": "1.0.4",
-                "gauge": "1.2.2"
+                "ansi": "~0.3.0",
+                "are-we-there-yet": "~1.0.0",
+                "gauge": "~1.2.0"
               },
               "dependencies": {
                 "ansi": {
@@ -11522,8 +11560,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "delegates": "0.1.0",
-                    "readable-stream": "1.1.13"
+                    "delegates": "^0.1.0",
+                    "readable-stream": "^1.1.13"
                   },
                   "dependencies": {
                     "delegates": {
@@ -11536,10 +11574,10 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "core-util-is": "1.0.1",
-                        "inherits": "2.0.1",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -11566,11 +11604,11 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "ansi": "0.3.0",
-                    "has-unicode": "1.0.1",
-                    "lodash.pad": "3.1.1",
-                    "lodash.padleft": "3.1.1",
-                    "lodash.padright": "3.1.1"
+                    "ansi": "^0.3.0",
+                    "has-unicode": "^1.0.0",
+                    "lodash.pad": "^3.0.0",
+                    "lodash.padleft": "^3.0.0",
+                    "lodash.padright": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash.pad": {
@@ -11578,8 +11616,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "lodash._basetostring": "3.0.1",
-                        "lodash._createpadding": "3.6.1"
+                        "lodash._basetostring": "^3.0.0",
+                        "lodash._createpadding": "^3.0.0"
                       },
                       "dependencies": {
                         "lodash._basetostring": {
@@ -11592,7 +11630,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "lodash.repeat": "3.0.1"
+                            "lodash.repeat": "^3.0.0"
                           },
                           "dependencies": {
                             "lodash.repeat": {
@@ -11600,7 +11638,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "lodash._basetostring": "3.0.1"
+                                "lodash._basetostring": "^3.0.0"
                               }
                             }
                           }
@@ -11612,8 +11650,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "lodash._basetostring": "3.0.1",
-                        "lodash._createpadding": "3.6.1"
+                        "lodash._basetostring": "^3.0.0",
+                        "lodash._createpadding": "^3.0.0"
                       },
                       "dependencies": {
                         "lodash._basetostring": {
@@ -11626,7 +11664,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "lodash.repeat": "3.0.1"
+                            "lodash.repeat": "^3.0.0"
                           },
                           "dependencies": {
                             "lodash.repeat": {
@@ -11634,7 +11672,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "lodash._basetostring": "3.0.1"
+                                "lodash._basetostring": "^3.0.0"
                               }
                             }
                           }
@@ -11646,8 +11684,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "lodash._basetostring": "3.0.1",
-                        "lodash._createpadding": "3.6.1"
+                        "lodash._basetostring": "^3.0.0",
+                        "lodash._createpadding": "^3.0.0"
                       },
                       "dependencies": {
                         "lodash._basetostring": {
@@ -11660,7 +11698,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "lodash.repeat": "3.0.1"
+                            "lodash.repeat": "^3.0.0"
                           },
                           "dependencies": {
                             "lodash.repeat": {
@@ -11668,7 +11706,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "lodash._basetostring": "3.0.1"
+                                "lodash._basetostring": "^3.0.0"
                               }
                             }
                           }
@@ -11686,8 +11724,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.1.4",
-            "semver": "5.1.0"
+            "hosted-git-info": "^2.1.4",
+            "semver": "4 || 5"
           }
         },
         "npm-registry-client": {
@@ -11695,19 +11733,19 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chownr": "1.0.1",
-            "concat-stream": "1.5.1",
-            "graceful-fs": "4.1.2",
-            "mkdirp": "0.5.1",
-            "normalize-package-data": "2.3.5",
-            "npm-package-arg": "4.1.0",
-            "npmlog": "2.0.0",
-            "once": "1.3.3",
-            "request": "2.67.0",
-            "retry": "0.8.0",
-            "rimraf": "2.5.0",
-            "semver": "5.1.0",
-            "slide": "1.1.6"
+            "chownr": "^1.0.1",
+            "concat-stream": "^1.4.6",
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "^0.5.0",
+            "normalize-package-data": "~1.0.1 || ^2.0.0",
+            "npm-package-arg": "^3.0.0 || ^4.0.0",
+            "npmlog": "~2.0.0",
+            "once": "^1.3.0",
+            "request": "^2.47.0",
+            "retry": "^0.8.0",
+            "rimraf": "2",
+            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+            "slide": "^1.1.3"
           },
           "dependencies": {
             "concat-stream": {
@@ -11715,9 +11753,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inherits": "2.0.1",
-                "readable-stream": "2.0.5",
-                "typedarray": "0.0.6"
+                "inherits": "~2.0.1",
+                "readable-stream": "~2.0.0",
+                "typedarray": "~0.0.5"
               },
               "dependencies": {
                 "typedarray": {
@@ -11739,9 +11777,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi": "0.3.0",
-            "are-we-there-yet": "1.0.4",
-            "gauge": "1.2.2"
+            "ansi": "~0.3.0",
+            "are-we-there-yet": "~1.0.0",
+            "gauge": "~1.2.0"
           },
           "dependencies": {
             "ansi": {
@@ -11754,8 +11792,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "delegates": "0.1.0",
-                "readable-stream": "1.1.13"
+                "delegates": "^0.1.0",
+                "readable-stream": "^1.1.13"
               },
               "dependencies": {
                 "delegates": {
@@ -11768,10 +11806,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.1",
-                    "inherits": "2.0.1",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -11798,11 +11836,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi": "0.3.0",
-                "has-unicode": "1.0.1",
-                "lodash.pad": "3.1.1",
-                "lodash.padleft": "3.1.1",
-                "lodash.padright": "3.1.1"
+                "ansi": "^0.3.0",
+                "has-unicode": "^1.0.0",
+                "lodash.pad": "^3.0.0",
+                "lodash.padleft": "^3.0.0",
+                "lodash.padright": "^3.0.0"
               },
               "dependencies": {
                 "lodash.pad": {
@@ -11810,8 +11848,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "lodash._basetostring": "3.0.1",
-                    "lodash._createpadding": "3.6.1"
+                    "lodash._basetostring": "^3.0.0",
+                    "lodash._createpadding": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._basetostring": {
@@ -11824,7 +11862,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "lodash.repeat": "3.0.1"
+                        "lodash.repeat": "^3.0.0"
                       },
                       "dependencies": {
                         "lodash.repeat": {
@@ -11832,7 +11870,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "lodash._basetostring": "3.0.1"
+                            "lodash._basetostring": "^3.0.0"
                           }
                         }
                       }
@@ -11844,8 +11882,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "lodash._basetostring": "3.0.1",
-                    "lodash._createpadding": "3.6.1"
+                    "lodash._basetostring": "^3.0.0",
+                    "lodash._createpadding": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._basetostring": {
@@ -11858,7 +11896,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "lodash.repeat": "3.0.1"
+                        "lodash.repeat": "^3.0.0"
                       },
                       "dependencies": {
                         "lodash.repeat": {
@@ -11866,7 +11904,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "lodash._basetostring": "3.0.1"
+                            "lodash._basetostring": "^3.0.0"
                           }
                         }
                       }
@@ -11878,8 +11916,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "lodash._basetostring": "3.0.1",
-                    "lodash._createpadding": "3.6.1"
+                    "lodash._basetostring": "^3.0.0",
+                    "lodash._createpadding": "^3.0.0"
                   },
                   "dependencies": {
                     "lodash._basetostring": {
@@ -11892,7 +11930,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "lodash.repeat": "3.0.1"
+                        "lodash.repeat": "^3.0.0"
                       },
                       "dependencies": {
                         "lodash.repeat": {
@@ -11900,7 +11938,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "lodash._basetostring": "3.0.1"
+                            "lodash._basetostring": "^3.0.0"
                           }
                         }
                       }
@@ -11922,7 +11960,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.1"
+            "wrappy": "1"
           }
         },
         "opener": {
@@ -11935,8 +11973,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.1",
-            "os-tmpdir": "1.0.1"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           },
           "dependencies": {
             "os-homedir": {
@@ -11961,7 +11999,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mute-stream": "0.0.5"
+            "mute-stream": "~0.0.4"
           },
           "dependencies": {
             "mute-stream": {
@@ -11976,7 +12014,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.2"
+            "graceful-fs": "^4.1.2"
           }
         },
         "read-installed": {
@@ -11984,13 +12022,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "graceful-fs": "4.1.2",
-            "read-package-json": "2.0.2",
-            "readdir-scoped-modules": "1.0.2",
-            "semver": "5.1.0",
-            "slide": "1.1.6",
-            "util-extend": "1.0.1"
+            "debuglog": "^1.0.1",
+            "graceful-fs": "^4.1.2",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "slide": "~1.1.3",
+            "util-extend": "^1.0.1"
           },
           "dependencies": {
             "util-extend": {
@@ -12005,10 +12043,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "5.0.15",
-            "graceful-fs": "4.1.2",
-            "json-parse-helpfulerror": "1.0.3",
-            "normalize-package-data": "2.3.5"
+            "glob": "^5.0.3",
+            "graceful-fs": "^4.1.2",
+            "json-parse-helpfulerror": "^1.0.2",
+            "normalize-package-data": "^2.0.0"
           },
           "dependencies": {
             "glob": {
@@ -12017,11 +12055,11 @@
               "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
               "dev": true,
               "requires": {
-                "inflight": "1.0.4",
-                "inherits": "2.0.1",
-                "minimatch": "3.0.4",
-                "once": "1.3.3",
-                "path-is-absolute": "1.0.1"
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "json-parse-helpfulerror": {
@@ -12029,7 +12067,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "jju": "1.2.1"
+                "jju": "^1.1.0"
               },
               "dependencies": {
                 "jju": {
@@ -12046,11 +12084,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "once": "1.3.3",
-            "read-package-json": "2.0.2",
-            "readdir-scoped-modules": "1.0.2"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "once": "^1.3.0",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0"
           }
         },
         "readable-stream": {
@@ -12058,12 +12096,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.1",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "process-nextick-args": "1.0.6",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
           },
           "dependencies": {
             "core-util-is": {
@@ -12098,10 +12136,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "graceful-fs": "4.1.2",
-            "once": "1.3.3"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "graceful-fs": "^4.1.2",
+            "once": "^1.3.0"
           }
         },
         "realize-package-specifier": {
@@ -12109,8 +12147,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "dezalgo": "1.0.3",
-            "npm-package-arg": "4.1.0"
+            "dezalgo": "^1.0.1",
+            "npm-package-arg": "^4.0.0"
           }
         },
         "request": {
@@ -12118,26 +12156,26 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "bl": "1.0.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.0",
-            "forever-agent": "0.6.1",
-            "form-data": "1.0.0-rc3",
-            "har-validator": "2.0.3",
-            "hawk": "3.1.2",
-            "http-signature": "1.1.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.8",
-            "node-uuid": "1.4.7",
-            "oauth-sign": "0.8.0",
-            "qs": "5.2.0",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.2.1",
-            "tunnel-agent": "0.4.2"
+            "aws-sign2": "~0.6.0",
+            "bl": "~1.0.0",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~1.0.0-rc3",
+            "har-validator": "~2.0.2",
+            "hawk": "~3.1.0",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "node-uuid": "~1.4.7",
+            "oauth-sign": "~0.8.0",
+            "qs": "~5.2.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.2.0",
+            "tunnel-agent": "~0.4.1"
           },
           "dependencies": {
             "aws-sign2": {
@@ -12150,7 +12188,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "readable-stream": "2.0.5"
+                "readable-stream": "~2.0.0"
               }
             },
             "caseless": {
@@ -12163,7 +12201,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
               },
               "dependencies": {
                 "delayed-stream": {
@@ -12188,9 +12226,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "async": "1.5.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.8"
+                "async": "^1.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.3"
               },
               "dependencies": {
                 "async": {
@@ -12205,10 +12243,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "chalk": "1.1.1",
-                "commander": "2.9.0",
-                "is-my-json-valid": "2.12.3",
-                "pinkie-promise": "2.0.0"
+                "chalk": "^1.1.1",
+                "commander": "^2.9.0",
+                "is-my-json-valid": "^2.12.3",
+                "pinkie-promise": "^2.0.0"
               },
               "dependencies": {
                 "chalk": {
@@ -12216,11 +12254,11 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "ansi-styles": "2.1.0",
-                    "escape-string-regexp": "1.0.3",
-                    "has-ansi": "2.0.0",
-                    "strip-ansi": "3.0.0",
-                    "supports-color": "2.0.0"
+                    "ansi-styles": "^2.1.0",
+                    "escape-string-regexp": "^1.0.2",
+                    "has-ansi": "^2.0.0",
+                    "strip-ansi": "^3.0.0",
+                    "supports-color": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-styles": {
@@ -12238,7 +12276,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "2.0.0"
+                        "ansi-regex": "^2.0.0"
                       }
                     },
                     "supports-color": {
@@ -12253,7 +12291,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "graceful-readlink": "1.0.1"
+                    "graceful-readlink": ">= 1.0.0"
                   },
                   "dependencies": {
                     "graceful-readlink": {
@@ -12268,10 +12306,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "generate-function": "2.0.0",
-                    "generate-object-property": "1.2.0",
+                    "generate-function": "^2.0.0",
+                    "generate-object-property": "^1.1.0",
                     "jsonpointer": "2.0.0",
-                    "xtend": "4.0.1"
+                    "xtend": "^4.0.0"
                   },
                   "dependencies": {
                     "generate-function": {
@@ -12284,7 +12322,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "is-property": "1.0.2"
+                        "is-property": "^1.0.0"
                       },
                       "dependencies": {
                         "is-property": {
@@ -12311,7 +12349,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "pinkie": "2.0.1"
+                    "pinkie": "^2.0.0"
                   },
                   "dependencies": {
                     "pinkie": {
@@ -12328,10 +12366,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
               },
               "dependencies": {
                 "boom": {
@@ -12339,7 +12377,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "hoek": "2.16.3"
+                    "hoek": "2.x.x"
                   }
                 },
                 "cryptiles": {
@@ -12347,7 +12385,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "boom": "2.10.1"
+                    "boom": "2.x.x"
                   }
                 },
                 "hoek": {
@@ -12360,7 +12398,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "hoek": "2.16.3"
+                    "hoek": "2.x.x"
                   }
                 }
               }
@@ -12370,9 +12408,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "assert-plus": "0.1.5",
-                "jsprim": "1.2.2",
-                "sshpk": "1.7.1"
+                "assert-plus": "^0.1.5",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -12415,13 +12453,13 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "0.2.0",
-                    "dashdash": "1.10.1",
-                    "ecc-jsbn": "0.1.1",
-                    "jodid25519": "1.0.2",
-                    "jsbn": "0.1.0",
-                    "tweetnacl": "0.13.2"
+                    "asn1": ">=0.2.3 <0.3.0",
+                    "assert-plus": ">=0.2.0 <0.3.0",
+                    "dashdash": ">=1.10.1 <2.0.0",
+                    "ecc-jsbn": ">=0.0.1 <1.0.0",
+                    "jodid25519": ">=1.0.0 <2.0.0",
+                    "jsbn": ">=0.1.0 <0.2.0",
+                    "tweetnacl": ">=0.13.0 <1.0.0"
                   },
                   "dependencies": {
                     "asn1": {
@@ -12439,7 +12477,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "assert-plus": "0.1.5"
+                        "assert-plus": "0.1.x"
                       },
                       "dependencies": {
                         "assert-plus": {
@@ -12455,7 +12493,7 @@
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "0.1.0"
+                        "jsbn": "~0.1.0"
                       }
                     },
                     "jodid25519": {
@@ -12464,7 +12502,7 @@
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "0.1.0"
+                        "jsbn": "~0.1.0"
                       }
                     },
                     "jsbn": {
@@ -12503,7 +12541,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "mime-db": "1.20.0"
+                "mime-db": "~1.20.0"
               },
               "dependencies": {
                 "mime-db": {
@@ -12555,7 +12593,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "6.0.3"
+            "glob": "^6.0.1"
           },
           "dependencies": {
             "glob": {
@@ -12563,11 +12601,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inflight": "1.0.4",
-                "inherits": "2.0.1",
-                "minimatch": "3.0.0",
-                "once": "1.3.3",
-                "path-is-absolute": "1.0.0"
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               },
               "dependencies": {
                 "minimatch": {
@@ -12575,7 +12613,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.2"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -12583,7 +12621,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.3.0",
+                        "balanced-match": "^0.3.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -12620,8 +12658,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.2",
-            "readable-stream": "2.0.5"
+            "graceful-fs": "^4.1.2",
+            "readable-stream": "^2.0.2"
           }
         },
         "slide": {
@@ -12639,7 +12677,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.0.0"
+            "ansi-regex": "^2.0.0"
           }
         },
         "tar": {
@@ -12647,9 +12685,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "block-stream": "0.0.8",
-            "fstream": "1.0.8",
-            "inherits": "2.0.1"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           },
           "dependencies": {
             "block-stream": {
@@ -12657,7 +12695,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inherits": "2.0.1"
+                "inherits": "~2.0.0"
               }
             }
           }
@@ -12682,7 +12720,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "unique-slug": "2.0.0"
+            "unique-slug": "^2.0.0"
           },
           "dependencies": {
             "unique-slug": {
@@ -12690,7 +12728,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "imurmurhash": "0.1.4"
+                "imurmurhash": "^0.1.4"
               }
             }
           }
@@ -12705,8 +12743,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "1.0.1",
-            "spdx-expression-parse": "1.0.0"
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
           },
           "dependencies": {
             "spdx-correct": {
@@ -12714,7 +12752,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "spdx-license-ids": "1.0.2"
+                "spdx-license-ids": "^1.0.2"
               }
             },
             "spdx-expression-parse": {
@@ -12722,8 +12760,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "spdx-exceptions": "1.0.3",
-                "spdx-license-ids": "1.0.2"
+                "spdx-exceptions": "^1.0.0",
+                "spdx-license-ids": "^1.0.0"
               },
               "dependencies": {
                 "spdx-exceptions": {
@@ -12760,7 +12798,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-absolute": "0.1.7"
+            "is-absolute": "^0.1.7"
           },
           "dependencies": {
             "is-absolute": {
@@ -12768,7 +12806,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-relative": "0.1.3"
+                "is-relative": "^0.1.0"
               },
               "dependencies": {
                 "is-relative": {
@@ -12790,9 +12828,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.2",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
+            "graceful-fs": "^4.1.2",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
           }
         }
       }
@@ -12809,8 +12847,8 @@
       "integrity": "sha1-WTMD/eqF98Qid18X+et2cPaA4+w=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "semver": "5.4.1"
+        "hosted-git-info": "^2.1.5",
+        "semver": "^5.1.0"
       }
     },
     "npm-run-path": {
@@ -12819,7 +12857,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npmlog": {
@@ -12828,10 +12866,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nth-check": {
@@ -12840,7 +12878,7 @@
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "number-is-nan": {
@@ -12871,8 +12909,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "on-finished": {
@@ -12895,7 +12933,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -12910,8 +12948,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.2"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -12920,12 +12958,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -12948,10 +12986,10 @@
       "integrity": "sha1-gAeN0rkqk0r2ajrXKluRBpTt5Ro=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "2.1.0",
-        "cli-spinners": "1.1.0",
-        "log-symbols": "1.0.2"
+        "chalk": "^1.1.1",
+        "cli-cursor": "^2.1.0",
+        "cli-spinners": "^1.0.0",
+        "log-symbols": "^1.0.2"
       },
       "dependencies": {
         "cli-cursor": {
@@ -12960,7 +12998,7 @@
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "onetime": {
@@ -12969,7 +13007,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "restore-cursor": {
@@ -12978,8 +13016,8 @@
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         }
       }
@@ -12995,7 +13033,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
     "os-shim": {
@@ -13015,8 +13053,8 @@
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "output-file-sync": {
@@ -13025,9 +13063,9 @@
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
+        "graceful-fs": "^4.1.4",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.0"
       }
     },
     "p-finally": {
@@ -13048,7 +13086,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "^1.1.0"
       }
     },
     "parse-bmfont-ascii": {
@@ -13069,8 +13107,8 @@
       "integrity": "sha1-1rZqNxr9OcUAfZ8O6yYqTyzOe3w=",
       "dev": true,
       "requires": {
-        "xml-parse-from-string": "1.0.1",
-        "xml2js": "0.4.19"
+        "xml-parse-from-string": "^1.0.0",
+        "xml2js": "^0.4.5"
       }
     },
     "parse-glob": {
@@ -13079,10 +13117,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-headers": {
@@ -13091,7 +13129,7 @@
       "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
       "dev": true,
       "requires": {
-        "for-each": "0.3.2",
+        "for-each": "^0.3.2",
         "trim": "0.0.1"
       }
     },
@@ -13101,7 +13139,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-passwd": {
@@ -13116,7 +13154,7 @@
       "integrity": "sha1-9cKtfHmTSQmGAgooTBmu5FlxH/I=",
       "dev": true,
       "requires": {
-        "pngjs": "3.3.1"
+        "pngjs": "^3.2.0"
       }
     },
     "parsejson": {
@@ -13125,7 +13163,7 @@
       "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseqs": {
@@ -13134,7 +13172,7 @@
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseuri": {
@@ -13143,7 +13181,7 @@
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseurl": {
@@ -13158,7 +13196,7 @@
       "integrity": "sha1-oBpdxjnvAH3FY2S4F4VpCArTp7g=",
       "dev": true,
       "requires": {
-        "exec-file-sync": "2.0.2"
+        "exec-file-sync": "^2.0.0"
       }
     },
     "path-exists": {
@@ -13206,9 +13244,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -13237,15 +13275,15 @@
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.2",
-        "extract-zip": "1.6.6",
-        "fs-extra": "1.0.0",
-        "hasha": "2.2.0",
-        "kew": "0.7.0",
-        "progress": "1.1.8",
-        "request": "2.83.0",
-        "request-progress": "2.0.1",
-        "which": "1.3.0"
+        "es6-promise": "^4.0.3",
+        "extract-zip": "^1.6.5",
+        "fs-extra": "^1.0.0",
+        "hasha": "^2.2.0",
+        "kew": "^0.7.0",
+        "progress": "^1.1.8",
+        "request": "^2.81.0",
+        "request-progress": "^2.0.1",
+        "which": "^1.2.10"
       },
       "dependencies": {
         "es6-promise": {
@@ -13260,9 +13298,9 @@
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0"
           }
         },
         "progress": {
@@ -13291,7 +13329,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pixelmatch": {
@@ -13300,7 +13338,7 @@
       "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
       "dev": true,
       "requires": {
-        "pngjs": "3.3.1"
+        "pngjs": "^3.0.0"
       }
     },
     "pluralize": {
@@ -13333,9 +13371,9 @@
       "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1"
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
       },
       "dependencies": {
         "async": {
@@ -13387,7 +13425,7 @@
       "integrity": "sha1-FZDfz1uPKYO6U+OYRGtoJAtMxoo=",
       "dev": true,
       "requires": {
-        "node-modules-path": "1.0.1"
+        "node-modules-path": "^1.0.0"
       }
     },
     "progress": {
@@ -13401,7 +13439,7 @@
       "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
       "requires": {
-        "rsvp": "3.6.2"
+        "rsvp": "^3.0.14"
       }
     },
     "proxy-addr": {
@@ -13410,7 +13448,7 @@
       "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.5.2"
       }
     },
@@ -13443,9 +13481,9 @@
       "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.8.tgz",
       "integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=",
       "requires": {
-        "mktemp": "0.4.0",
-        "rimraf": "2.6.2",
-        "underscore.string": "3.3.4"
+        "mktemp": "~0.4.0",
+        "rimraf": "^2.5.4",
+        "underscore.string": "~3.3.4"
       }
     },
     "qunit": {
@@ -13469,7 +13507,7 @@
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "findup-sync": {
@@ -13478,10 +13516,10 @@
           "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
           "dev": true,
           "requires": {
-            "detect-file": "0.1.0",
-            "is-glob": "2.0.1",
-            "micromatch": "2.3.11",
-            "resolve-dir": "0.1.1"
+            "detect-file": "^0.1.0",
+            "is-glob": "^2.0.1",
+            "micromatch": "^2.3.7",
+            "resolve-dir": "^0.1.0"
           }
         },
         "resolve": {
@@ -13490,7 +13528,7 @@
           "integrity": "sha1-HwRCyeDLuBNuh7kwX5MvRsfygjU=",
           "dev": true,
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         },
         "walk-sync": {
@@ -13499,8 +13537,8 @@
           "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
           "dev": true,
           "requires": {
-            "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.5"
+            "ensure-posix-path": "^1.0.0",
+            "matcher-collection": "^1.0.0"
           }
         }
       }
@@ -13511,8 +13549,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -13521,7 +13559,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13530,7 +13568,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -13541,7 +13579,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -13576,9 +13614,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -13587,8 +13625,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -13597,8 +13635,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-exists": {
@@ -13607,7 +13645,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -13618,10 +13656,10 @@
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
         "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
+        "string_decoder": "~0.10.x"
       },
       "dependencies": {
         "isarray": {
@@ -13638,10 +13676,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       },
       "dependencies": {
         "readable-stream": {
@@ -13650,13 +13688,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -13665,7 +13703,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -13677,10 +13715,10 @@
       "dev": true,
       "requires": {
         "ast-types": "0.10.1",
-        "core-js": "2.5.3",
-        "esprima": "4.0.0",
-        "private": "0.1.8",
-        "source-map": "0.6.1"
+        "core-js": "^2.4.1",
+        "esprima": "~4.0.0",
+        "private": "~0.1.5",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -13697,8 +13735,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "redeyed": {
@@ -13707,7 +13745,7 @@
       "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
       "dev": true,
       "requires": {
-        "esprima": "3.0.0"
+        "esprima": "~3.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -13729,12 +13767,12 @@
       "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
       "dev": true,
       "requires": {
-        "commoner": "0.10.8",
-        "defs": "1.1.1",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "private": "0.1.8",
+        "commoner": "~0.10.3",
+        "defs": "~1.1.0",
+        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+        "private": "~0.1.5",
         "recast": "0.10.33",
-        "through": "2.3.8"
+        "through": "~2.3.8"
       },
       "dependencies": {
         "ast-types": {
@@ -13756,9 +13794,9 @@
           "dev": true,
           "requires": {
             "ast-types": "0.8.12",
-            "esprima-fb": "15001.1001.0-dev-harmony-fb",
-            "private": "0.1.8",
-            "source-map": "0.5.7"
+            "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+            "private": "~0.1.5",
+            "source-map": "~0.5.0"
           }
         }
       }
@@ -13773,9 +13811,9 @@
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -13784,7 +13822,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regexpu": {
@@ -13793,11 +13831,11 @@
       "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "recast": "0.10.43",
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "esprima": "^2.6.0",
+        "recast": "^0.10.10",
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       },
       "dependencies": {
         "ast-types": {
@@ -13819,9 +13857,9 @@
           "dev": true,
           "requires": {
             "ast-types": "0.8.15",
-            "esprima-fb": "15001.1001.0-dev-harmony-fb",
-            "private": "0.1.8",
-            "source-map": "0.5.7"
+            "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+            "private": "~0.1.5",
+            "source-map": "~0.5.0"
           },
           "dependencies": {
             "esprima-fb": {
@@ -13839,9 +13877,9 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
@@ -13854,7 +13892,7 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       }
     },
     "remove-trailing-separator": {
@@ -13880,7 +13918,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "replace-ext": {
@@ -13895,28 +13933,28 @@
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "request-progress": {
@@ -13925,7 +13963,7 @@
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "requires": {
-        "throttleit": "1.0.0"
+        "throttleit": "^1.0.0"
       }
     },
     "require-dir": {
@@ -13969,8 +14007,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "requires-port": {
@@ -13986,11 +14024,11 @@
       "dev": true,
       "requires": {
         "bmp-js": "0.0.1",
-        "file-type": "3.9.0",
-        "get-stream": "2.3.1",
-        "jimp": "0.2.28",
-        "jpeg-js": "0.1.2",
-        "parse-png": "1.1.2"
+        "file-type": "^3.8.0",
+        "get-stream": "^2.0.0",
+        "jimp": "^0.2.21",
+        "jpeg-js": "^0.1.1",
+        "parse-png": "^1.1.1"
       },
       "dependencies": {
         "bmp-js": {
@@ -14005,8 +14043,8 @@
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "jpeg-js": {
@@ -14022,7 +14060,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-dir": {
@@ -14031,8 +14069,8 @@
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "1.2.2",
-        "global-modules": "0.2.3"
+        "expand-tilde": "^1.2.2",
+        "global-modules": "^0.2.3"
       }
     },
     "resolve-from": {
@@ -14047,8 +14085,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "right-align": {
@@ -14057,7 +14095,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -14065,7 +14103,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "rollup": {
@@ -14074,7 +14112,7 @@
       "integrity": "sha1-4NBUl4d6OYwQTYFtJzOnGKepTio=",
       "dev": true,
       "requires": {
-        "source-map-support": "0.4.18"
+        "source-map-support": "^0.4.0"
       }
     },
     "rsvp": {
@@ -14088,7 +14126,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rx": {
@@ -14109,7 +14147,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "4.0.8"
+        "rx-lite": "*"
       }
     },
     "safe-buffer": {
@@ -14130,13 +14168,13 @@
       "integrity": "sha1-s1ebzLRclM8gNVzIESSZDf00bjA=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "exec-sh": "0.2.1",
-        "fb-watchman": "2.0.0",
-        "minimatch": "3.0.4",
-        "minimist": "1.2.0",
-        "walker": "1.0.7",
-        "watch": "0.10.0"
+        "anymatch": "^1.3.0",
+        "exec-sh": "^0.2.0",
+        "fb-watchman": "^2.0.0",
+        "minimatch": "^3.0.2",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5",
+        "watch": "~0.10.0"
       },
       "dependencies": {
         "minimist": {
@@ -14153,10 +14191,10 @@
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "7.1.0"
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^7.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -14171,9 +14209,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -14182,7 +14220,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -14191,9 +14229,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "yargs": {
@@ -14202,19 +14240,19 @@
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
           }
         }
       }
@@ -14231,8 +14269,8 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.4.0",
-        "source-map": "0.4.4"
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
       },
       "dependencies": {
         "source-map": {
@@ -14241,7 +14279,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -14258,18 +14296,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.2",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
       },
       "dependencies": {
         "mime": {
@@ -14286,9 +14324,9 @@
       "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.1"
       }
     },
@@ -14316,7 +14354,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -14343,7 +14381,7 @@
       "integrity": "sha1-IglwbxyFCp8dENDYQJGLRvJuG8k=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9"
+        "debug": "^2.2.0"
       }
     },
     "simple-dom": {
@@ -14375,7 +14413,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       }
     },
     "snake-case": {
@@ -14384,7 +14422,7 @@
       "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2"
+        "no-case": "^2.2.0"
       }
     },
     "sntp": {
@@ -14393,7 +14431,7 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "socket.io": {
@@ -14550,7 +14588,7 @@
       "integrity": "sha1-8uX7/+hCDMG7BEhfRQnwXnO0wPI=",
       "dev": true,
       "requires": {
-        "sort-object-keys": "1.1.2"
+        "sort-object-keys": "^1.1.1"
       }
     },
     "source-map": {
@@ -14563,7 +14601,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "source-map-url": {
@@ -14578,10 +14616,10 @@
       "integrity": "sha1-q9Lx7Nrmo8RsLJbF8lZwWyFHycA=",
       "dev": true,
       "requires": {
-        "jsesc": "0.3.0",
-        "lodash.foreach": "2.3.0",
-        "lodash.template": "2.3.0",
-        "source-map": "0.1.43"
+        "jsesc": "~0.3.x",
+        "lodash.foreach": "~2.3.x",
+        "lodash.template": "~2.3.x",
+        "source-map": "~0.1.x"
       },
       "dependencies": {
         "jsesc": {
@@ -14596,13 +14634,13 @@
           "integrity": "sha1-Tj4pxDO0z+pnXsg15vEjkcYf0is=",
           "dev": true,
           "requires": {
-            "lodash._escapestringchar": "2.3.0",
-            "lodash._reinterpolate": "2.3.0",
-            "lodash.defaults": "2.3.0",
-            "lodash.escape": "2.3.0",
-            "lodash.keys": "2.3.0",
-            "lodash.templatesettings": "2.3.0",
-            "lodash.values": "2.3.0"
+            "lodash._escapestringchar": "~2.3.0",
+            "lodash._reinterpolate": "~2.3.0",
+            "lodash.defaults": "~2.3.0",
+            "lodash.escape": "~2.3.0",
+            "lodash.keys": "~2.3.0",
+            "lodash.templatesettings": "~2.3.0",
+            "lodash.values": "~2.3.0"
           }
         },
         "source-map": {
@@ -14611,7 +14649,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -14628,8 +14666,8 @@
       "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
-        "os-shim": "0.1.3"
+        "concat-stream": "^1.4.7",
+        "os-shim": "^0.1.2"
       }
     },
     "spawnback": {
@@ -14644,7 +14682,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -14676,14 +14714,14 @@
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stable": {
@@ -14704,7 +14742,7 @@
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.1"
       },
       "dependencies": {
         "readable-stream": {
@@ -14713,13 +14751,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -14728,7 +14766,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -14745,7 +14783,7 @@
       "integrity": "sha1-JnmdkDqyAlyb1VCsRxcbAPjdgKk=",
       "dev": true,
       "requires": {
-        "stream-to": "0.2.2"
+        "stream-to": "~0.2.0"
       }
     },
     "string-template": {
@@ -14760,8 +14798,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -14776,7 +14814,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -14816,7 +14854,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -14837,7 +14875,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -14858,7 +14896,7 @@
       "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.0.0"
       }
     },
     "supports-color": {
@@ -14872,9 +14910,9 @@
       "integrity": "sha1-omRNaLAjGsAK9DGqFjcU/xcQZEc=",
       "dev": true,
       "requires": {
-        "phantomjs-prebuilt": "2.1.16",
-        "pn": "1.0.0",
-        "yargs": "3.32.0"
+        "phantomjs-prebuilt": "^2.1.10",
+        "pn": "^1.0.0",
+        "yargs": "^3.31.0"
       },
       "dependencies": {
         "camelcase": {
@@ -14889,9 +14927,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -14900,7 +14938,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -14909,9 +14947,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "yargs": {
@@ -14920,13 +14958,13 @@
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "dev": true,
           "requires": {
-            "camelcase": "2.1.1",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "os-locale": "1.4.0",
-            "string-width": "1.0.2",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
           }
         }
       }
@@ -14942,12 +14980,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.3.0",
-        "lodash": "4.17.4",
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14956,7 +14994,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -14965,9 +15003,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -14976,7 +15014,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -14987,9 +15025,9 @@
       "integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
       "dev": true,
       "requires": {
-        "events-to-array": "1.1.2",
-        "js-yaml": "3.10.0",
-        "readable-stream": "2.3.3"
+        "events-to-array": "^1.0.1",
+        "js-yaml": "^3.2.7",
+        "readable-stream": "^2"
       },
       "dependencies": {
         "readable-stream": {
@@ -14999,13 +15037,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -15015,7 +15053,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -15026,9 +15064,9 @@
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "temp": {
@@ -15037,8 +15075,8 @@
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2",
-        "rimraf": "2.2.8"
+        "os-tmpdir": "^1.0.0",
+        "rimraf": "~2.2.6"
       },
       "dependencies": {
         "rimraf": {
@@ -15055,32 +15093,32 @@
       "integrity": "sha1-5F/tkivsL1SmFsQ/EZIlmKyX60E=",
       "dev": true,
       "requires": {
-        "backbone": "1.3.3",
-        "bluebird": "3.5.1",
-        "charm": "1.0.2",
-        "commander": "2.12.2",
-        "consolidate": "0.14.5",
-        "cross-spawn": "5.1.0",
-        "express": "4.16.2",
-        "fireworm": "0.7.1",
-        "glob": "7.1.2",
-        "http-proxy": "1.16.2",
-        "js-yaml": "3.10.0",
-        "lodash.assignin": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.find": "4.6.0",
-        "lodash.uniqby": "4.7.0",
-        "mkdirp": "0.5.1",
-        "mustache": "2.3.0",
-        "node-notifier": "5.1.2",
-        "npmlog": "4.1.2",
-        "printf": "0.2.5",
-        "rimraf": "2.6.2",
+        "backbone": "^1.1.2",
+        "bluebird": "^3.4.6",
+        "charm": "^1.0.0",
+        "commander": "^2.6.0",
+        "consolidate": "^0.14.0",
+        "cross-spawn": "^5.1.0",
+        "express": "^4.10.7",
+        "fireworm": "^0.7.0",
+        "glob": "^7.0.4",
+        "http-proxy": "^1.13.1",
+        "js-yaml": "^3.2.5",
+        "lodash.assignin": "^4.1.0",
+        "lodash.clonedeep": "^4.4.1",
+        "lodash.find": "^4.5.1",
+        "lodash.uniqby": "^4.7.0",
+        "mkdirp": "^0.5.1",
+        "mustache": "^2.2.1",
+        "node-notifier": "^5.0.1",
+        "npmlog": "^4.0.0",
+        "printf": "^0.2.3",
+        "rimraf": "^2.4.4",
         "socket.io": "1.6.0",
-        "spawn-args": "0.2.0",
+        "spawn-args": "^0.2.0",
         "styled_string": "0.0.1",
-        "tap-parser": "5.4.0",
-        "xmldom": "0.1.27"
+        "tap-parser": "^5.1.0",
+        "xmldom": "^0.1.19"
       },
       "dependencies": {
         "bluebird": {
@@ -15120,8 +15158,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       },
       "dependencies": {
         "readable-stream": {
@@ -15130,13 +15168,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -15145,7 +15183,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -15156,12 +15194,12 @@
       "integrity": "sha512-YrxUSiMgOVh3PnAqtdAUQuUVEVRnqcRCxJ3BHrl/aaWV2fplKKB60oClM0GH2Gio2hcXvkxMUxsC/vXZrQePlg==",
       "dev": true,
       "requires": {
-        "body": "5.1.0",
-        "debug": "2.6.9",
-        "faye-websocket": "0.10.0",
-        "livereload-js": "2.2.2",
-        "object-assign": "4.1.1",
-        "qs": "6.5.1"
+        "body": "^5.1.0",
+        "debug": "~2.6.7",
+        "faye-websocket": "~0.10.0",
+        "livereload-js": "^2.2.2",
+        "object-assign": "^4.1.0",
+        "qs": "^6.4.0"
       }
     },
     "tinycolor2": {
@@ -15175,7 +15213,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.1"
       }
     },
     "tmpl": {
@@ -15201,11 +15239,11 @@
       "integrity": "sha512-5kIh7m7bkIlqIESEZkL8gAMMzucXKfPe3hX2FoDY5HEAfD9OJU+Qh9b6Enp74w0qRcxVT5ejss66PHKqc3AVkg==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "buffer-alloc": "1.1.0",
-        "image-size": "0.5.5",
-        "parse-png": "1.1.2",
-        "resize-img": "1.1.2"
+        "arrify": "^1.0.1",
+        "buffer-alloc": "^1.1.0",
+        "image-size": "^0.5.0",
+        "parse-png": "^1.0.0",
+        "resize-img": "^1.1.0"
       },
       "dependencies": {
         "image-size": {
@@ -15222,7 +15260,7 @@
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "tree-sync": {
@@ -15230,11 +15268,11 @@
       "resolved": "https://registry.npmjs.org/tree-sync/-/tree-sync-1.2.2.tgz",
       "integrity": "sha1-LPdrhYn1n/7bWNtaOsfLAT0BWLc=",
       "requires": {
-        "debug": "2.6.9",
-        "fs-tree-diff": "0.5.7",
-        "mkdirp": "0.5.1",
-        "quick-temp": "0.1.8",
-        "walk-sync": "0.2.7"
+        "debug": "^2.2.0",
+        "fs-tree-diff": "^0.5.6",
+        "mkdirp": "^0.5.1",
+        "quick-temp": "^0.1.5",
+        "walk-sync": "^0.2.7"
       },
       "dependencies": {
         "walk-sync": {
@@ -15242,8 +15280,8 @@
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
           "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
           "requires": {
-            "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.5"
+            "ensure-posix-path": "^1.0.0",
+            "matcher-collection": "^1.0.0"
           }
         }
       }
@@ -15271,7 +15309,7 @@
       "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
       "dev": true,
       "requires": {
-        "glob": "6.0.4"
+        "glob": "^6.0.4"
       },
       "dependencies": {
         "glob": {
@@ -15280,11 +15318,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -15307,7 +15345,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -15323,7 +15361,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-is": {
@@ -15333,7 +15371,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
+        "mime-types": "~2.1.15"
       }
     },
     "typedarray": {
@@ -15355,9 +15393,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "window-size": {
@@ -15374,9 +15412,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -15406,8 +15444,8 @@
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
       "requires": {
-        "sprintf-js": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "sprintf-js": "^1.0.3",
+        "util-deprecate": "^1.0.2"
       }
     },
     "unique-string": {
@@ -15416,7 +15454,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "universalify": {
@@ -15437,7 +15475,7 @@
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "url-regex": {
@@ -15446,7 +15484,7 @@
       "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
       "dev": true,
       "requires": {
-        "ip-regex": "1.0.3"
+        "ip-regex": "^1.0.1"
       }
     },
     "user-home": {
@@ -15461,9 +15499,9 @@
       "integrity": "sha1-gcgrftY+Z0wkdWZ2U0E7PHb94jk=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "passwd-user": "1.2.1",
-        "username": "1.0.1"
+        "os-homedir": "^1.0.1",
+        "passwd-user": "^1.2.1",
+        "username": "^1.0.1"
       }
     },
     "username": {
@@ -15472,7 +15510,7 @@
       "integrity": "sha1-4fcilePljgbwAsYyfOBol6mc1n8=",
       "dev": true,
       "requires": {
-        "meow": "3.7.0"
+        "meow": "^3.4.0"
       }
     },
     "username-sync": {
@@ -15503,8 +15541,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "validate-npm-package-name": {
@@ -15513,7 +15551,7 @@
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "requires": {
-        "builtins": "1.0.3"
+        "builtins": "^1.0.3"
       }
     },
     "vary": {
@@ -15528,9 +15566,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vinyl": {
@@ -15539,8 +15577,8 @@
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "dev": true,
       "requires": {
-        "clone": "1.0.3",
-        "clone-stats": "0.0.1",
+        "clone": "^1.0.0",
+        "clone-stats": "^0.0.1",
         "replace-ext": "0.0.1"
       },
       "dependencies": {
@@ -15557,8 +15595,8 @@
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
       "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
       "requires": {
-        "ensure-posix-path": "1.0.2",
-        "matcher-collection": "1.0.5"
+        "ensure-posix-path": "^1.0.0",
+        "matcher-collection": "^1.0.0"
       }
     },
     "walker": {
@@ -15567,7 +15605,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.11"
+        "makeerror": "1.0.x"
       }
     },
     "watch": {
@@ -15582,8 +15620,8 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.9",
-        "websocket-extensions": "0.1.3"
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
@@ -15598,7 +15636,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -15613,7 +15651,7 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -15622,7 +15660,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -15631,9 +15669,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -15664,8 +15702,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -15674,7 +15712,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -15683,9 +15721,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -15701,7 +15739,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -15710,9 +15748,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "ws": {
@@ -15721,8 +15759,8 @@
       "integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg=",
       "dev": true,
       "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
       }
     },
     "wtf-8": {
@@ -15743,10 +15781,10 @@
       "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
       "dev": true,
       "requires": {
-        "global": "4.3.2",
-        "is-function": "1.0.1",
-        "parse-headers": "2.0.1",
-        "xtend": "4.0.1"
+        "global": "~4.3.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "xml-parse-from-string": {
@@ -15761,8 +15799,8 @@
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.4"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
@@ -15807,8 +15845,8 @@
       "integrity": "sha1-OKdst5oZKE2SBu1JAx41mhNAvQY=",
       "dev": true,
       "requires": {
-        "fs-extra": "0.30.0",
-        "lodash.merge": "4.6.0"
+        "fs-extra": "^0.30.0",
+        "lodash.merge": "^4.4.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -15817,11 +15855,11 @@
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         }
       }
@@ -15832,12 +15870,12 @@
       "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
       "dev": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
-        "os-locale": "1.4.0",
-        "window-size": "0.1.4",
-        "y18n": "3.2.1"
+        "camelcase": "^1.2.1",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "os-locale": "^1.4.0",
+        "window-size": "^0.1.2",
+        "y18n": "^3.2.0"
       }
     },
     "yargs-parser": {
@@ -15846,7 +15884,7 @@
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0"
+        "camelcase": "^3.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -15863,7 +15901,7 @@
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "dev": true,
       "requires": {
-        "fd-slicer": "1.0.1"
+        "fd-slicer": "~1.0.1"
       }
     },
     "yeast": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outdoorsyco/ember-initials",
   "author": "Exelord",
-  "version": "3.6.1-beta.1",
+  "version": "3.6.1",
   "license": "MIT",
   "homepage": "https://github.com/Exelord/ember-initials#readme",
   "description": "Simple Initails Avatars for Ember 2 applications",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ember-initials",
+  "name": "@outdoorsyco/ember-initials",
   "author": "Exelord",
-  "version": "3.6.0",
+  "version": "3.6.1-beta.1",
   "license": "MIT",
   "homepage": "https://github.com/Exelord/ember-initials#readme",
   "description": "Simple Initails Avatars for Ember 2 applications",

--- a/package.json
+++ b/package.json
@@ -65,14 +65,10 @@
     "loader.js": "4.6.0"
   },
   "dependencies": {
-    "blueimp-md5": "2.10.0",
     "broccoli-funnel": "2.0.1",
     "broccoli-merge-trees": "2.0.0",
     "ember-cli-babel": "6.11.0"
   },
-  "fastbootDependencies": [
-    "blueimp-md5"
-  ],
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "demoURL": "https://github.com/Exelord/ember-initials/"

--- a/tests/unit/services/ember-initials-store-test.js
+++ b/tests/unit/services/ember-initials-store-test.js
@@ -1,5 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
-import Base from 'ember-initials/utils/generators/base';
+import Base from '@outdoorsyco/ember-initials/utils/generators/base';
 
 moduleFor('service:ember-initials-store', 'Unit | Service | initials store');
 

--- a/tests/unit/utils/color-index-test.js
+++ b/tests/unit/utils/color-index-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import ColorIndex from 'ember-initials/utils/color-index';
+import ColorIndex from '@outdoorsyco/ember-initials/utils/color-index';
 
 module('Unit | Utils | Color Index');
 

--- a/tests/unit/utils/initials-test.js
+++ b/tests/unit/utils/initials-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import Initials from 'ember-initials/utils/initials';
+import Initials from '@outdoorsyco/ember-initials/utils/initials';
 
 module('Unit | Utils | Initials');
 


### PR DESCRIPTION
Removes all remnants of blueimp-md5, which wasn't being used and was causing errors.

Also scopes this package under `@outdoorsyco`, so we can refer to that in apps.

NOTE: This component will someday be replaced by https://github.com/freshbooks/initials-avatar via https://app.asana.com/0/1107438932159734/1131031794119450